### PR TITLE
Add compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2349,7 +2349,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
         "accepts": "1.3.4",
@@ -2829,7 +2829,8 @@
     "dotenv": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+      "dev": true
     },
     "dottie": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "babel-runtime": "^6.26.0",
     "body-parser": "^1.18.2",
     "chalk": "^2.3.0",
-    "compression": "^1.7.1",
+    "compression": "^1.7.2",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.1",
@@ -72,7 +72,10 @@
     "test": "cross-env NODE_ENV=test jest __tests__",
     "test:watch": "cross-env NODE_ENV=test jest __tests__ --watch",
     "test:security": "nsp check",
-    "test:lint": "eslint --env node --ext .js server"
+    "test:lint": "./node_modules/.bin/eslint --max-warnings 3 - src",
+    "test:lint": "eslint --env node --ext .js server",
+    "db:migrate": "sequelize --url $POSTGRES_URL db:migrate",
+    "db:seed": "sequelize --url $POSTGRES_URL db:seed:all"
   },
   "repository": {
     "type": "git",

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,7 @@
 
 'use strict';
 
+import compression from 'compression';
 import path from 'path';
 import fs from 'fs';
 import express from 'express';
@@ -60,6 +61,7 @@ fs.access(docpath, fs.constants.R_OK, (err) => {
   app.use('/doc', express.static(docpath));
 });
 
+app.use(compression());
 app.use(cookieParser());
 app.use(bodyParser.urlencoded({
   extended: true,

--- a/server/libs/db/index.js
+++ b/server/libs/db/index.js
@@ -25,7 +25,7 @@ export default class DataManager {
       underscored: true,
       operatorsAliases: Sequelize.Op,
       pool: {
-        max: 5,
+        max: 3,
         min: 0,
         acquire: 30000,
         idle: 10000,


### PR DESCRIPTION
Add compression capability to the API. Clients can add the standard header `Accept-Encoding: deflate, gzip` to ask the API to use compression. I also tweaked the db pool parameters; this should have no visible impact on the system.