### PR TITLE
Fix pasture create

### DIFF
--- a/server/router/routes/agreement.js
+++ b/server/router/routes/agreement.js
@@ -158,7 +158,7 @@ router.post('/', asyncMiddleware(async (req, res) => {
 router.get('/', asyncMiddleware(async (req, res) => {
   try {
     const agreements = await Agreement.findAll({
-      limit: 100,
+      limit: 10,
       include: allAgreementChildren,
       attributes: {
         exclude: excludedAgreementAttributes,

--- a/server/router/routes/plan.js
+++ b/server/router/routes/plan.js
@@ -186,7 +186,7 @@ router.post('/:planId?/pasture', asyncMiddleware(async (req, res) => {
 
   try {
     const plan = await Plan.findById(planId);
-    const pasture = await Pasture.create(body);
+    const pasture = await Pasture.create(Object.assign(body, { planId }));
 
     await plan.addPasture(pasture);
 


### PR DESCRIPTION
Get the planId from the URL path and limit the number of agreements returned to 10 until pagination is implemented.