### PR TITLE
Fix record count

### DIFF
--- a/server/router/routes/agreement.js
+++ b/server/router/routes/agreement.js
@@ -218,13 +218,14 @@ router.get('/', asyncMiddleware(async (req, res) => {
 
     let result;
     if (page) {
-      //
+      // Its a bit tough to get the count from Sequlize but a raw query works great. A where clause
+      // is applied only if the user is not an administrator.
       let query = 'SELECT count(*) FROM agreement JOIN ref_zone ON agreement.zone_id = ref_zone.id';
       if (!req.user.isAdministrator()) {
         query = `${query} WHERE ref_zone.user_id = ${req.user.id}`;
       }
       const [response] = await dm.sequelize.query(query, { type: dm.sequelize.QueryTypes.SELECT });
-      console.log(response);
+
       result = {
         perPage: limit,
         currentPage: Number(page),


### PR DESCRIPTION
I'm using a raw query to get the record count if the user is *not* an administrator. I've tested local with a user who owns multiple zones and an administrator.