### PR TITLE
Add a guard on when to ignore token exp

### DIFF
--- a/server/libs/authmware.js
+++ b/server/libs/authmware.js
@@ -125,7 +125,11 @@ const authmware = async (app) => {
   opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
   opts.algorithms = ['RS256'];
   opts.secretOrKey = await getJwtSecret();
-  opts.ignoreExpiration = true;
+  // For development purposes only ignore the expiration
+  // time of tokens.
+  if (config.get('environment') === 'development') {
+    opts.ignoreExpiration = true;
+  }
 
   const jwtStrategy = new JwtStrategy(opts, async (jwtPayload, done) => {
     try {


### PR DESCRIPTION
To make sure ignoring the token does not split out of development I put a guard in place.