### PR TITLE
Enable BCeID

### DIFF
--- a/server/libs/db/index.js
+++ b/server/libs/db/index.js
@@ -76,7 +76,7 @@ export default class DataManager {
     //
     // User Role
     //
-    this.User.belongsTo(this.UserRole, { foreignKey: 'role_id' });
+    // this.User.belongsTo(this.UserRole, { foreignKey: 'role_id' });
 
     //
     // Client, Agreement

--- a/server/libs/db/migrations/2018042601-alter-table-user_active.js
+++ b/server/libs/db/migrations/2018042601-alter-table-user_active.js
@@ -1,0 +1,56 @@
+//
+// MyRA
+//
+// Copyright © 2018 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Jason Leach on 2018-04-26.
+//
+
+/* eslint-env es6 */
+
+'use strict';
+
+/* eslint-disable no-unused-vars,arrow-body-style */
+const table = 'user_account';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(
+      table,
+      'active',
+      {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+    );
+
+    await queryInterface.changeColumn(
+      table,
+      'active',
+      {
+        type: Sequelize.STRING(64),
+      },
+    );
+
+    await queryInterface.removeColumn(table, 'role_id');
+
+    const query = `UPDATE ${table} SET active = FALSE`;
+    await queryInterface.sequelize.query(query);
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn(table, 'active');
+  },
+};

--- a/server/libs/db/models/User.js
+++ b/server/libs/db/models/User.js
@@ -34,7 +34,7 @@ export default (sequelize, DataTypes) => {
     },
     username: {
       allowNull: false,
-      type: DataTypes.STRING(16),
+      type: DataTypes.STRING(64),
       unique: true,
     },
     givenName: {
@@ -54,10 +54,10 @@ export default (sequelize, DataTypes) => {
       field: 'phone_number',
       type: DataTypes.STRING(32),
     },
-    roleId: {
-      field: 'role_id',
+    active: {
       allowNull: false,
-      type: DataTypes.INTEGER,
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
     },
     lastLoginAt: {
       field: 'last_login_at',


### PR DESCRIPTION
Enable BCeID for agreement holder functionality. As part of this new users to the system are automatically registered as a user on the system but not given any access until the account is vetted and assigned Agreements (Client) or Zones (Range Officer).

