### PR TITLE
Allow delete of a grazing schedule

### DIFF
--- a/server/libs/db2/model/model.js
+++ b/server/libs/db2/model/model.js
@@ -199,6 +199,18 @@ export default class Model {
     }
   }
 
+  static removeById(db, id) {
+    const where = {};
+    where[this.primaryKey] = id;
+
+    const results = db
+      .table(this.table)
+      .where(where)
+      .delete();
+
+    return results;
+  }
+
   // extract a models properties from the given data
   static extract(data) {
     const obj = {};

--- a/server/router/routes/plan.js
+++ b/server/router/routes/plan.js
@@ -428,10 +428,15 @@ router.delete('/:planId?/schedule/:scheduleId?', asyncMiddleware(async (req, res
     // WARNING: This will do a cascading delete on any grazing schedule
     // entries. It will not modify other relations.
     const result = await GrazingSchedule.removeById(db, scheduleId);
-    console.log(result); // for debugging only.
+    if (result === 0) {
+      throw errorWithCode('No such schedule exists', 400);
+    }
 
     return res.status(204).end();
   } catch (error) {
+    const message = `Unable to delete schedule ${scheduleId}`;
+    logger.error(`${message}, error = ${error.message}`);
+
     throw error;
   }
 }));


### PR DESCRIPTION
@Kyubinhan This is still a WIP. Open a PR for discussion.

I think that DELETE should *not* accept a hierarchy; If you want to delete an _entry_ you delete it like:
`DELETE /planId/schedule/scheduleId/entry/entryId`

If you DELETE an entire schedule, do it like this:
`DELETE /planId/schedule/scheduleId`
This will delete all related grazing schedule entries because I set `ON DELETE CASCADE` set as part of the foresight key constraint. No other relations will be touched (pasture, livestock, etc).

The DELETE will just return 204 in both cases (Accepted / No Response).