### PR TITLE
remove the first two commands to just run import.js in npm run import

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test:watch": "cross-env NODE_ENV=test jest __tests__ --watch",
     "test:security": "nsp check",
     "test:lint": "eslint --env node --ext .js server",
-    "import": "npx knex migrate:latest && npx knex seed:run && npx babel-node scripts/import.js"
+    "import": "npx babel-node scripts/import.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
the first two commands have been removed in 'npm run import'