### PR TITLE
Parameterize the job run time

### DIFF
--- a/openshift/templates/fetch-fta-data.yaml
+++ b/openshift/templates/fetch-fta-data.yaml
@@ -119,22 +119,22 @@ parameters:
   - name: 'SUCCESS_JOBS_HISTORY_LIMIT'
     displayName: 'Successful Job History Limit'
     description: 'The number of successful jobs that will be retained'
-    value: 3
+    value: '3'
     required: true
   - name: 'FAILED_JOBS_HISTORY_LIMIT'
     displayName: 'Failed Job History Limit'
     description: 'The number of failed jobs that will be retained'
-    value: 3
+    value: '3'
     required: true
   - name: 'JOB_BACKOFF_LIMIT'
     displayName: 'Job Backoff Limit'
     description: 'The number of attempts to try for a successful job outcome (default: 6)'
-    value: 0
+    value: '0'
     required: false
   - name: 'ACTIVE_DEADLINE'
     displayName: 'Active Deadline in Seconds'
     description: 'How long is a job allowed to run for before it is killed'
-    value: 600
+    value: '600'
     required: true
   - name: 'FTA_API_STORE_USERNAME'
     displayName: 'API Store Username'

--- a/openshift/templates/fetch-fta-data.yaml
+++ b/openshift/templates/fetch-fta-data.yaml
@@ -29,15 +29,15 @@ objects:
     spec:
       schedule: '${SCHEDULE}'
       concurrencyPolicy: 'Forbid'
-      successfulJobsHistoryLimit: ${{SUCCESS_JOBS_HISTORY_LIMIT}}
-      failedJobsHistoryLimit: ${{FAILED_JOBS_HISTORY_LIMIT}}
+      successfulJobsHistoryLimit: ${SUCCESS_JOBS_HISTORY_LIMIT}
+      failedJobsHistoryLimit: ${FAILED_JOBS_HISTORY_LIMIT}
       jobTemplate:
         metadata:
           labels:
             template: 'devhub-cronjob'
             cronjob: '${JOB_NAME}'
         spec:
-          backoffLimit: ${{JOB_BACKOFF_LIMIT}}
+          backoffLimit: ${JOB_BACKOFF_LIMIT}
           template:
             spec:
               containers:
@@ -81,7 +81,7 @@ objects:
                           key: database-password
               restartPolicy: 'Never'
               terminationGracePeriodSeconds: 30
-              activeDeadlineSeconds: 600
+              activeDeadlineSeconds: ${ACTIVE_DEADLINE}
               dnsPolicy: 'ClusterFirst'
               # serviceAccountName: '${JOB_SERVICE_ACCOUNT}'
               # serviceAccount: '${JOB_SERVICE_ACCOUNT}'
@@ -119,18 +119,23 @@ parameters:
   - name: 'SUCCESS_JOBS_HISTORY_LIMIT'
     displayName: 'Successful Job History Limit'
     description: 'The number of successful jobs that will be retained'
-    value: '3'
+    value: 3
     required: true
   - name: 'FAILED_JOBS_HISTORY_LIMIT'
     displayName: 'Failed Job History Limit'
     description: 'The number of failed jobs that will be retained'
-    value: '3'
+    value: 3
     required: true
   - name: 'JOB_BACKOFF_LIMIT'
     displayName: 'Job Backoff Limit'
     description: 'The number of attempts to try for a successful job outcome (default: 6)'
-    value: '0'
+    value: 0
     required: false
+  - name: 'ACTIVE_DEADLINE'
+    displayName: 'Active Deadline in Seconds'
+    description: 'How long is a job allowed to run for before it is killed'
+    value: 600
+    required: true
   - name: 'FTA_API_STORE_USERNAME'
     displayName: 'API Store Username'
     description: 'The username of the NRS API store account'


### PR DESCRIPTION
Now you can specify `-p ACTIVE_DEADLINE=1800` to custom set the permitted run-time. This value is in seconds so 1800 is 30 min.