### PR TITLE
Parameterize the database name

### DIFF
--- a/openshift/templates/fetch-fta-data.yaml
+++ b/openshift/templates/fetch-fta-data.yaml
@@ -65,10 +65,7 @@ objects:
                     - name: POSTGRESQL_HOST
                       value: ${POSTGRESQL_HOST}
                     - name: POSTGRESQL_DATABASE
-                      valueFrom:
-                        secretKeyRef:
-                          name: postgresql
-                          key: database-name
+                      value: ${POSTGRESQL_DATABASE}
                     - name: POSTGRESQL_USER
                       valueFrom:
                         secretKeyRef:
@@ -151,4 +148,8 @@ parameters:
   - name: 'POSTGRESQL_HOST'
     displayName: 'PostgreSQL Service Name'
     description: 'The name of the postgres service (fetch it from oc)'
+    required: true
+  - name: 'POSTGRESQL_DATABASE'
+    displayName: 'PostgreSQL Database Name'
+    description: 'The name of the postgres database'
     required: true


### PR DESCRIPTION
Looks like in `prod` the database name is no longer stored in a secret; this is actually a better way to do it. I've updated the batch job template to reflect this.