### PR TITLE
Fix db credentials secret ref

### DIFF
--- a/openshift/templates/fetch-fta-data.yaml
+++ b/openshift/templates/fetch-fta-data.yaml
@@ -70,12 +70,12 @@ objects:
                       valueFrom:
                         secretKeyRef:
                           name: postgresql
-                          key: database-user
+                          key: user
                     - name: POSTGRESQL_PASSWORD
                       valueFrom:
                         secretKeyRef:
                           name: postgresql
-                          key: database-password
+                          key: password
               restartPolicy: 'Never'
               terminationGracePeriodSeconds: 30
               activeDeadlineSeconds: ${ACTIVE_DEADLINE}


### PR DESCRIPTION
The database credentials secret has different keys to dev and test. This PR fixes this; we'll need to go back and fix dev and test later.