### PR TITLE
create two migration files for plan and agreement tables

### DIFF
--- a/src/libs/db2/migrations/20190329154322_add_approved_plan_to_plan.js
+++ b/src/libs/db2/migrations/20190329154322_add_approved_plan_to_plan.js
@@ -1,0 +1,37 @@
+
+//
+// MyRA
+//
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Kyubin Han
+//
+
+'use strict';
+
+/* eslint-disable no-unused-vars */
+
+const table = 'plan';
+
+exports.up = async knex =>
+  knex.schema.table(table, async (t) => {
+    // TODO: save the plan object in this field the moment when the plan is approved.
+    t.json('approved_plan'); // to store the snapshot of the approved plan
+  });
+
+exports.down = knex =>
+  knex.schema.table(table, async (t) => {
+    t.dropColumn('approved_plan');
+  });

--- a/src/libs/db2/migrations/20190329154552_add_current_approved_plan_id_to_agreement.js
+++ b/src/libs/db2/migrations/20190329154552_add_current_approved_plan_id_to_agreement.js
@@ -1,0 +1,37 @@
+
+//
+// MyRA
+//
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Created by Kyubin Han
+//
+
+'use strict';
+
+/* eslint-disable no-unused-vars */
+
+const table = 'agreement';
+
+exports.up = async knex =>
+  knex.schema.table(table, async (t) => {
+    // TODO: update this field every time a new plan is approved
+    t.integer('current_approved_plan_id'); // to keep track of the most recent approved plan or amendment
+  });
+
+exports.down = knex =>
+  knex.schema.table(table, async (t) => {
+    t.dropColumn('current_approved_plan_id');
+  });


### PR DESCRIPTION
@micheal-w-wells I have created these migration files so that you can work on it later.
Here are the links of the trello cards related to this merge.

https://trello.com/c/gs93EYIc/1557-api-save-a-snapshot-of-for-each-approved-plan
https://trello.com/c/EsztuVYM/1559-api-add-a-column-in-the-plan-table-to-save-the-current-approved-plan-id

I will leave this open and let you decide whether you keep it open or close.