### PR TITLE
Add plan versioning

### DIFF
--- a/__mocks__/fixtures/additional_requirement_mock.json
+++ b/__mocks__/fixtures/additional_requirement_mock.json
@@ -1,7 +1,7 @@
 [
   {
     "canonical_id": 2,
-    "plan_id": 1,
+    "plan_id": 2,
     "category_id": 2,
     "detail": "Details here"
   }

--- a/__mocks__/fixtures/additional_requirement_mock.json
+++ b/__mocks__/fixtures/additional_requirement_mock.json
@@ -1,0 +1,8 @@
+[
+  {
+    "canonical_id": 2,
+    "plan_id": 1,
+    "category_id": 2,
+    "detail": "Details here"
+  }
+]

--- a/__mocks__/fixtures/indicator_plant_mock.json
+++ b/__mocks__/fixtures/indicator_plant_mock.json
@@ -1,0 +1,8 @@
+[
+  {
+    "canonical_id": 1,
+    "criteria": "rangereadiness",
+    "plant_species_id": 2,
+    "plant_community_id": 1
+  }
+]

--- a/__mocks__/fixtures/invasive_plant_mock.json
+++ b/__mocks__/fixtures/invasive_plant_mock.json
@@ -1,0 +1,7 @@
+[
+  {
+    "plan_id": 2,
+    "equipment_and_vehicles_parking": true,
+    "begin_in_uninfested_area": false
+  }
+]

--- a/__mocks__/fixtures/management_consideration_mock.json
+++ b/__mocks__/fixtures/management_consideration_mock.json
@@ -1,5 +1,6 @@
 [
   {
+    "canonical_id": 1,
     "consideration_type_id": 2,
     "plan_id": 1,
     "detail": "Details for the consideration",

--- a/__mocks__/fixtures/management_consideration_mock.json
+++ b/__mocks__/fixtures/management_consideration_mock.json
@@ -2,7 +2,7 @@
   {
     "canonical_id": 1,
     "consideration_type_id": 2,
-    "plan_id": 1,
+    "plan_id": 2,
     "detail": "Details for the consideration",
     "url": "http://example.com",
     "created_at": "2019-03-28T16:35:58.040Z",

--- a/__mocks__/fixtures/minister_issue_action_mock.json
+++ b/__mocks__/fixtures/minister_issue_action_mock.json
@@ -1,5 +1,6 @@
 [
   {
+    "canonical_id": 1,
     "detail":"This is an action!",
     "issue_id": 1,
     "action_type_id": 4,

--- a/__mocks__/fixtures/minister_issue_mock.json
+++ b/__mocks__/fixtures/minister_issue_mock.json
@@ -5,6 +5,6 @@
     "objective": "Our objective is to address the issue....",
     "identified": true,
     "issue_type_id": 2,
-    "plan_id": 1
+    "plan_id": 2
   }
 ]

--- a/__mocks__/fixtures/minister_issue_mock.json
+++ b/__mocks__/fixtures/minister_issue_mock.json
@@ -1,5 +1,6 @@
 [
   {
+    "canonical_id": 1,
     "detail": "This is a pretty big issue",
     "objective": "Our objective is to address the issue....",
     "identified": true,

--- a/__mocks__/fixtures/minister_issue_pasture_mock.json
+++ b/__mocks__/fixtures/minister_issue_pasture_mock.json
@@ -1,0 +1,7 @@
+[
+  {
+    "canonical_id": 1,
+    "minister_issue_id": 1,
+    "pasture_id": 1
+  }
+]

--- a/__mocks__/fixtures/monitoring_area_mock.json
+++ b/__mocks__/fixtures/monitoring_area_mock.json
@@ -1,0 +1,7 @@
+[
+  {
+    "canonical_id": 1,
+    "plant_community_id": 1,
+    "name": "my area"
+  }
+]

--- a/__mocks__/fixtures/monitoring_area_purpose_mock.json
+++ b/__mocks__/fixtures/monitoring_area_purpose_mock.json
@@ -1,0 +1,7 @@
+[
+  {
+    "canonical_id": 1,
+    "purpose_type_id": 1,
+    "monitoring_area_id": 1
+  }
+]

--- a/__mocks__/fixtures/pasture_mock.json
+++ b/__mocks__/fixtures/pasture_mock.json
@@ -1,5 +1,6 @@
 [
   {
+    "canonical_id": 1,
     "plan_id": 1,
     "name": "XYZ's Pasture",
     "allowable_aum": 100,

--- a/__mocks__/fixtures/pasture_mock.json
+++ b/__mocks__/fixtures/pasture_mock.json
@@ -1,7 +1,7 @@
 [
   {
     "canonical_id": 1,
-    "plan_id": 1,
+    "plan_id": 2,
     "name": "XYZ's Pasture",
     "allowable_aum": 100,
     "grace_days": 10,

--- a/__mocks__/fixtures/plan_confirmation_mock.json
+++ b/__mocks__/fixtures/plan_confirmation_mock.json
@@ -1,6 +1,6 @@
 [
   {
-    "plan_id": 1,
+    "plan_id": 2,
     "client_id": "09999901",
     "confirmed": true,
     "created_at": "2019-03-28T16:35:58.040Z"

--- a/__mocks__/fixtures/plan_mock.json
+++ b/__mocks__/fixtures/plan_mock.json
@@ -15,5 +15,22 @@
     "effective_at": null,
     "submitted_at": null,
     "creator_id": 1
+  },
+  {
+    "canonical_id": 1,
+    "range_name": "XYZ's Range v2",
+    "plan_start_date": "2019-01-21T08:00:00.000Z",
+    "plan_end_date": "2022-12-30T08:00:00.000Z",
+    "notes": null,
+    "alt_business_name": null,
+    "agreement_id": "RAN123456",
+    "status_id": 1,
+    "uploaded": true,
+    "amendment_type_id": null,
+    "created_at": "2019-03-28T16:35:58.040Z",
+    "updated_at": "2019-03-28T16:35:58.040Z",
+    "effective_at": null,
+    "submitted_at": null,
+    "creator_id": 1
   }
 ]

--- a/__mocks__/fixtures/plan_mock.json
+++ b/__mocks__/fixtures/plan_mock.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 1,
+    "canonical_id": 1,
     "range_name": "XYZ's Range",
     "plan_start_date": "2019-01-21T08:00:00.000Z",
     "plan_end_date": "2022-12-30T08:00:00.000Z",

--- a/__mocks__/fixtures/plan_version_mock.json
+++ b/__mocks__/fixtures/plan_version_mock.json
@@ -2,13 +2,10 @@
   {
     "version": -1,
     "canonical_id": 1,
-    "plan_id": 1
+    "plan_id": 2
   },
   {
-    "canonical_id": 1,
-    "plan_id": 1
-  },
-  {
+    "version": 1,
     "canonical_id": 1,
     "plan_id": 1
   }

--- a/__mocks__/fixtures/plan_version_mock.json
+++ b/__mocks__/fixtures/plan_version_mock.json
@@ -5,7 +5,6 @@
     "plan_id": 2
   },
   {
-    "version": 1,
     "canonical_id": 1,
     "plan_id": 1
   }

--- a/__mocks__/fixtures/plan_version_mock.json
+++ b/__mocks__/fixtures/plan_version_mock.json
@@ -1,0 +1,15 @@
+[
+  {
+    "version": -1,
+    "canonical_id": 1,
+    "plan_id": 1
+  },
+  {
+    "canonical_id": 1,
+    "plan_id": 1
+  },
+  {
+    "canonical_id": 1,
+    "plan_id": 1
+  }
+]

--- a/__mocks__/fixtures/plant_community_action_mock.json
+++ b/__mocks__/fixtures/plant_community_action_mock.json
@@ -1,0 +1,7 @@
+[
+  {
+    "canonical_id": 1,
+    "plant_community_id": 1,
+    "action_type_id": 1
+  }
+]

--- a/__mocks__/fixtures/plant_community_mock.json
+++ b/__mocks__/fixtures/plant_community_mock.json
@@ -1,5 +1,6 @@
 [
   {
+    "canonical_id": 1,
     "pasture_id": 1,
     "community_type_id": 1,
     "purpose_of_action": "none",

--- a/__mocks__/fixtures/schedule_entry_mock.json
+++ b/__mocks__/fixtures/schedule_entry_mock.json
@@ -1,0 +1,8 @@
+[
+  {
+    "canonical_id": 1,
+    "livestock_type_id": 4,
+    "grazing_schedule_id": 1,
+    "pasture_id": 1
+  }
+]

--- a/__mocks__/fixtures/schedule_mock.json
+++ b/__mocks__/fixtures/schedule_mock.json
@@ -1,7 +1,7 @@
 [
   {
     "canonical_id": 1,
-    "plan_id": 1,
+    "plan_id": 2,
     "year": 2022,
     "narative": "Details for the schedule",
     "created_at": "2019-03-28T16:35:58.040Z",

--- a/__mocks__/fixtures/schedule_mock.json
+++ b/__mocks__/fixtures/schedule_mock.json
@@ -1,5 +1,6 @@
 [
   {
+    "canonical_id": 1,
     "plan_id": 1,
     "year": 2022,
     "narative": "Details for the schedule",

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -20,7 +20,6 @@ const { canAccessAgreement } = passport.aUser;
 const truncate = table => `TRUNCATE TABLE ${table} RESTART IDENTITY CASCADE`;
 const baseUrl = '/api/v1/plan';
 const body = {
-  id: 2,
   rangeName: 'Create Admin Test',
   planStartDate: '2019-01-21T08:00:00.000Z',
   planEndDate: '2022-12-30T08:00:00.000Z',
@@ -57,14 +56,13 @@ describe('Test Plan routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
-    const plan = planMocks[0];
     const clientAgreement = clientAgreementMocks[0];
     const planConfirmation = planConfirmationMocks[0];
     await dm.db('user_account').insert([user]);
     await dm.db('ref_zone').insert([zone]);
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
-    await dm.db('plan').insert([plan]);
+    await dm.db('plan').insert(planMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
     await dm.db('plan_version').insert(planVersionMocks);
   });
@@ -81,7 +79,10 @@ describe('Test Plan routes', () => {
       .get(`${baseUrl}/1`)
       .expect(200)
       .expect('Content-Type', /json/)
-      .expect(res => expect(res.body.id).toEqual(1));
+      .expect((res) => {
+        expect(res.body.id).toEqual(2);
+        expect(res.body.canonicalId).toEqual(1);
+      });
   });
 
   // GET /plan/:planId where planId does not exist
@@ -122,11 +123,11 @@ describe('Test Plan routes', () => {
 
     await request(app)
       .put(`${baseUrl}/1`)
-      .send({ ...body, id: 1, rangeName })
+      .send({ ...body, rangeName })
       .expect(200)
       .expect((res) => {
         const results = res.body;
-        expect(results.id).toEqual(1);
+        expect(results.id).toEqual(2);
         expect(results.rangeName).toEqual(rangeName);
       });
   });
@@ -146,7 +147,8 @@ describe('Test Plan routes', () => {
       .expect(200)
       .expect((res) => {
         const results = res.body;
-        expect(results.id).toEqual(1);
+        expect(results.id).toEqual(2);
+        expect(results.canonicalId).toEqual(1);
         expect(results.statusId).toEqual(12);
         expect(results.effectiveAt).toBeDefined();
       });

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -5,6 +5,7 @@ import userMocks from '../../__mocks__/fixtures/user_account_mock.json';
 import zoneMocks from '../../__mocks__/fixtures/ref_zone_mock.json';
 import agreementMocks from '../../__mocks__/fixtures/agreement_mock.json';
 import planMocks from '../../__mocks__/fixtures/plan_mock.json';
+import planVersionMocks from '../../__mocks__/fixtures/plan_version_mock.json';
 import clientAgreementMocks from '../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../__mocks__/fixtures/plan_confirmation_mock.json';
 import DataManager from '../../src/libs/db2';
@@ -37,6 +38,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('plan_confirmation'));
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
+  await dm.db.schema.raw(truncate('plan_version'));
   await dm.db.schema.raw(truncate('plan'));
 };
 
@@ -64,6 +66,7 @@ describe('Test Plan routes', () => {
     await dm.db('client_agreement').insert([clientAgreement]);
     await dm.db('plan').insert([plan]);
     await dm.db('plan_confirmation').insert([planConfirmation]);
+    await dm.db('plan_version').insert(planVersionMocks);
   });
 
   afterEach(async () => {

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -145,7 +145,7 @@ describe('Test Plan routes', () => {
         const results = res.body;
         expect(results.id).toEqual(1);
         expect(results.statusId).toEqual(12);
-        expect(results.effective_at).toBeDefined();
+        expect(results.effectiveAt).toBeDefined();
       });
   });
 

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -6,6 +6,20 @@ import zoneMocks from '../../__mocks__/fixtures/ref_zone_mock.json';
 import agreementMocks from '../../__mocks__/fixtures/agreement_mock.json';
 import planMocks from '../../__mocks__/fixtures/plan_mock.json';
 import planVersionMocks from '../../__mocks__/fixtures/plan_version_mock.json';
+import pastureMocks from '../../__mocks__/fixtures/pasture_mock.json';
+import plantCommunityMocks from '../../__mocks__/fixtures/plant_community_mock.json';
+import plantCommunityActionMocks from '../../__mocks__/fixtures/plant_community_action_mock.json';
+import indicatorPlantMocks from '../../__mocks__/fixtures/indicator_plant_mock.json';
+import monitoringAreaMocks from '../../__mocks__/fixtures/monitoring_area_mock.json';
+import monitoringAreaPurposeMocks from '../../__mocks__/fixtures/monitoring_area_purpose_mock.json';
+import grazingScheduleMocks from '../../__mocks__/fixtures/schedule_mock.json';
+import grazingScheduleEntryMocks from '../../__mocks__/fixtures/schedule_entry_mock.json';
+import additionalRequirementMocks from '../../__mocks__/fixtures/additional_requirement_mock.json';
+import ministerIssueMocks from '../../__mocks__/fixtures/minister_issue_mock.json';
+import ministerIssueActionMocks from '../../__mocks__/fixtures/minister_issue_action_mock.json';
+import ministerIssuePastureMocks from '../../__mocks__/fixtures/minister_issue_pasture_mock.json';
+import managementConsiderationMocks from '../../__mocks__/fixtures/management_consideration_mock.json';
+import invasivePlantMocks from '../../__mocks__/fixtures/invasive_plant_mock.json';
 import clientAgreementMocks from '../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../__mocks__/fixtures/plan_confirmation_mock.json';
 import DataManager from '../../src/libs/db2';
@@ -15,6 +29,15 @@ const dm = new DataManager(config);
 
 jest.mock('request-promise-native');
 
+const hasNested = (object, key, i = 0) => {
+  const keys = Object.keys(object);
+
+  if (Object.prototype.hasOwnProperty.call(object, key)) return true;
+  if (object && typeof object === 'object' && keys.length > 0) {
+    return Object.keys(object).some(k => object[k] && hasNested(object[k], key, i + 1));
+  }
+  return false;
+};
 
 const { canAccessAgreement } = passport.aUser;
 const truncate = table => `TRUNCATE TABLE ${table} RESTART IDENTITY CASCADE`;
@@ -37,8 +60,22 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('plan_confirmation'));
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
-  await dm.db.schema.raw(truncate('plan_version'));
+  await dm.db.schema.raw(truncate('management_consideration'));
+  await dm.db.schema.raw(truncate('minister_issue_pasture'));
+  await dm.db.schema.raw(truncate('minister_issue_action'));
+  await dm.db.schema.raw(truncate('minister_issue'));
+  await dm.db.schema.raw(truncate('additional_requirement'));
+  await dm.db.schema.raw(truncate('grazing_schedule_entry'));
+  await dm.db.schema.raw(truncate('grazing_schedule'));
+  await dm.db.schema.raw(truncate('monitoring_area_purpose'));
+  await dm.db.schema.raw(truncate('monitoring_area'));
+  await dm.db.schema.raw(truncate('indicator_plant'));
+  await dm.db.schema.raw(truncate('plant_community'));
+  await dm.db.schema.raw(truncate('plant_community_action'));
+  await dm.db.schema.raw(truncate('pasture'));
+  await dm.db.schema.raw(truncate('invasive_plant_checklist'));
   await dm.db.schema.raw(truncate('plan'));
+  await dm.db.schema.raw(truncate('plan_version'));
 };
 
 describe('Test Plan routes', () => {
@@ -56,6 +93,19 @@ describe('Test Plan routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
+    const pasture = pastureMocks[0];
+    const plantCommunity = plantCommunityMocks[0];
+    const plantCommunityAction = plantCommunityActionMocks[0];
+    const indicatorPlant = indicatorPlantMocks[0];
+    const monitoringArea = monitoringAreaMocks[0];
+    const monitoringAreaPurpose = monitoringAreaPurposeMocks[0];
+    const grazingSchedule = grazingScheduleMocks[0];
+    const grazingScheduleEntry = grazingScheduleEntryMocks[0];
+    const additionalRequirement = additionalRequirementMocks[0];
+    const ministerIssue = ministerIssueMocks[0];
+    const ministerIssueAction = ministerIssueActionMocks[0];
+    const ministerIssuePasture = ministerIssuePastureMocks[0];
+    const managementConsideration = managementConsiderationMocks[0];
     const clientAgreement = clientAgreementMocks[0];
     const planConfirmation = planConfirmationMocks[0];
     await dm.db('user_account').insert([user]);
@@ -63,8 +113,22 @@ describe('Test Plan routes', () => {
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
     await dm.db('plan').insert(planMocks);
-    await dm.db('plan_confirmation').insert([planConfirmation]);
     await dm.db('plan_version').insert(planVersionMocks);
+    await dm.db('plan_confirmation').insert([planConfirmation]);
+    await dm.db('pasture').insert([pasture]);
+    await dm.db('plant_community').insert([plantCommunity]);
+    await dm.db('plant_community_action').insert([plantCommunityAction]);
+    await dm.db('indicator_plant').insert([indicatorPlant]);
+    await dm.db('monitoring_area').insert([monitoringArea]);
+    await dm.db('monitoring_area_purpose').insert([monitoringAreaPurpose]);
+    await dm.db('grazing_schedule').insert([grazingSchedule]);
+    await dm.db('grazing_schedule_entry').insert([grazingScheduleEntry]);
+    await dm.db('additional_requirement').insert([additionalRequirement]);
+    await dm.db('minister_issue').insert([ministerIssue]);
+    await dm.db('minister_issue_action').insert([ministerIssueAction]);
+    await dm.db('minister_issue_pasture').insert([ministerIssuePasture]);
+    await dm.db('management_consideration').insert([managementConsideration]);
+    await dm.db('invasive_plant_checklist').insert(invasivePlantMocks);
   });
 
   afterEach(async () => {
@@ -81,6 +145,17 @@ describe('Test Plan routes', () => {
       .expect('Content-Type', /json/)
       .expect((res) => {
         expect(res.body.id).toEqual(1);
+      });
+  });
+
+  test.only("Fetching a plan doesn't include any canonical ids in the responses", async () => {
+    await request(app)
+      .get(`${baseUrl}/1`)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect((res) => {
+        expect(res.body.id).toEqual(1);
+        expect(hasNested(res.body, 'canonicalId')).not.toEqual(true);
       });
   });
 

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -80,8 +80,7 @@ describe('Test Plan routes', () => {
       .expect(200)
       .expect('Content-Type', /json/)
       .expect((res) => {
-        expect(res.body.id).toEqual(2);
-        expect(res.body.canonicalId).toEqual(1);
+        expect(res.body.id).toEqual(1);
       });
   });
 
@@ -127,7 +126,7 @@ describe('Test Plan routes', () => {
       .expect(200)
       .expect((res) => {
         const results = res.body;
-        expect(results.id).toEqual(2);
+        expect(results.id).toEqual(1);
         expect(results.rangeName).toEqual(rangeName);
       });
   });
@@ -147,8 +146,7 @@ describe('Test Plan routes', () => {
       .expect(200)
       .expect((res) => {
         const results = res.body;
-        expect(results.id).toEqual(2);
-        expect(results.canonicalId).toEqual(1);
+        expect(results.id).toEqual(1);
         expect(results.statusId).toEqual(12);
         expect(results.effectiveAt).toBeDefined();
       });

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -148,7 +148,7 @@ describe('Test Plan routes', () => {
       });
   });
 
-  test.only("Fetching a plan doesn't include any canonical ids in the responses", async () => {
+  test("Fetching a plan doesn't include any canonical ids in the responses", async () => {
     await request(app)
       .get(`${baseUrl}/1`)
       .expect(200)

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -187,7 +187,7 @@ describe('Test Plan routes', () => {
       .expect(200)
       .expect(res => expect(res.body.updatedAt).toBeDefined);
 
-    const results = await dm.db('plan').where('id', 1);
+    const results = await dm.db('plan').where('id', 2);
     expect(results).toHaveLength(1);
     expect(results[0].status_id).toEqual(14);
   });
@@ -208,6 +208,6 @@ describe('Test Plan routes', () => {
 
     const results = await dm.db('plan_status_history').where('id', 1);
     expect(results).toHaveLength(1);
-    expect(results[0].plan_id).toEqual(1);
+    expect(results[0].plan_id).toEqual(2);
   });
 });

--- a/__tests__/api_v1/plan/invasivePlants.spec.js
+++ b/__tests__/api_v1/plan/invasivePlants.spec.js
@@ -5,6 +5,7 @@ import userMocks from '../../../__mocks__/fixtures/user_account_mock.json';
 import zoneMocks from '../../../__mocks__/fixtures/ref_zone_mock.json';
 import agreementMocks from '../../../__mocks__/fixtures/agreement_mock.json';
 import planMocks from '../../../__mocks__/fixtures/plan_mock.json';
+import planVersionMocks from '../../../__mocks__/fixtures/plan_version_mock.json';
 import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../../__mocks__/fixtures/plan_confirmation_mock.json';
 import DataManager from '../../../src/libs/db2';
@@ -31,6 +32,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('plan_confirmation'));
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
+  await dm.db.schema.raw(truncate('plan_version'));
   await dm.db.schema.raw(truncate('plan'));
 };
 
@@ -49,14 +51,14 @@ describe('Test Invasive Plant routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
-    const plan = planMocks[0];
     const clientAgreement = clientAgreementMocks[0];
     const planConfirmation = planConfirmationMocks[0];
     await dm.db('user_account').insert([user]);
     await dm.db('ref_zone').insert([zone]);
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
-    await dm.db('plan').insert([plan]);
+    await dm.db('plan').insert(planMocks);
+    await dm.db('plan_version').insert(planVersionMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
   });
 
@@ -72,7 +74,7 @@ describe('Test Invasive Plant routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 1, planId: 1 });
+        expect(res.body).toEqual({ ...body, id: 1, planId: 2, canonicalId: 1 });
       });
   });
 
@@ -82,7 +84,7 @@ describe('Test Invasive Plant routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 1, planId: 1 });
+        expect(res.body).toEqual({ ...body, id: 1, planId: 2, canonicalId: 1 });
       });
 
     await request(app)
@@ -93,7 +95,7 @@ describe('Test Invasive Plant routes', () => {
 
   test('Creating an invasive plant checklist for a nonexistant plan throws a 500 error', async () => {
     await request(app)
-      .post('/api/v1/plan/10/invasive-plant-checklist')
+      .post('/api/v1/plan/2/invasive-plant-checklist')
       .send(body)
       .expect(500);
   });
@@ -104,7 +106,7 @@ describe('Test Invasive Plant routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 1, planId: 1 });
+        expect(res.body).toEqual({ ...body, id: 1, planId: 2, canonicalId: 1 });
       });
 
     await request(app)
@@ -112,7 +114,7 @@ describe('Test Invasive Plant routes', () => {
       .send({ ...body, equipmentAndVehiclesParking: false })
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, equipmentAndVehiclesParking: false, id: 1, planId: 1 });
+        expect(res.body).toEqual({ ...body, equipmentAndVehiclesParking: false, id: 1, planId: 2, canonicalId: 1 });
       });
   });
 

--- a/__tests__/api_v1/plan/invasivePlants.spec.js
+++ b/__tests__/api_v1/plan/invasivePlants.spec.js
@@ -74,7 +74,7 @@ describe('Test Invasive Plant routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 1, planId: 2, canonicalId: 1 });
+        expect(res.body).toEqual({ ...body, id: 1, planId: 2 });
       });
   });
 
@@ -84,7 +84,7 @@ describe('Test Invasive Plant routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 1, planId: 2, canonicalId: 1 });
+        expect(res.body).toEqual({ ...body, id: 1, planId: 2 });
       });
 
     await request(app)
@@ -106,7 +106,7 @@ describe('Test Invasive Plant routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 1, planId: 2, canonicalId: 1 });
+        expect(res.body).toEqual({ ...body, id: 1, planId: 2 });
       });
 
     await request(app)
@@ -114,7 +114,7 @@ describe('Test Invasive Plant routes', () => {
       .send({ ...body, equipmentAndVehiclesParking: false })
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, equipmentAndVehiclesParking: false, id: 1, planId: 2, canonicalId: 1 });
+        expect(res.body).toEqual({ ...body, equipmentAndVehiclesParking: false, id: 1, planId: 2 });
       });
   });
 

--- a/__tests__/api_v1/plan/management-consideration.spec.js
+++ b/__tests__/api_v1/plan/management-consideration.spec.js
@@ -81,7 +81,6 @@ describe('Test Management Consideration routes', () => {
           ...body,
           id: 2,
           planId: 2,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -105,7 +104,6 @@ describe('Test Management Consideration routes', () => {
           ...body,
           id: 2,
           planId: 2,
-          canonicalId: 2,
         });
       });
 
@@ -119,7 +117,6 @@ describe('Test Management Consideration routes', () => {
           id: 2,
           planId: 2,
           detail,
-          canonicalId: 2,
         });
       });
   });

--- a/__tests__/api_v1/plan/management-consideration.spec.js
+++ b/__tests__/api_v1/plan/management-consideration.spec.js
@@ -5,6 +5,7 @@ import userMocks from '../../../__mocks__/fixtures/user_account_mock.json';
 import zoneMocks from '../../../__mocks__/fixtures/ref_zone_mock.json';
 import agreementMocks from '../../../__mocks__/fixtures/agreement_mock.json';
 import planMocks from '../../../__mocks__/fixtures/plan_mock.json';
+import planVersionMocks from '../../../__mocks__/fixtures/plan_version_mock.json';
 import managementConsiderationMocks from '../../../__mocks__/fixtures/management_consideration_mock.json';
 import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../../__mocks__/fixtures/plan_confirmation_mock.json';
@@ -31,6 +32,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('plan_confirmation'));
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
+  await dm.db.schema.raw(truncate('plan_version'));
   await dm.db.schema.raw(truncate('plan'));
   await dm.db.schema.raw(truncate('management_consideration'));
 };
@@ -50,7 +52,6 @@ describe('Test Management Consideration routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
-    const plan = planMocks[0];
     const managementConsideration = managementConsiderationMocks[0];
     const clientAgreement = clientAgreementMocks[0];
     const planConfirmation = planConfirmationMocks[0];
@@ -58,7 +59,8 @@ describe('Test Management Consideration routes', () => {
     await dm.db('ref_zone').insert([zone]);
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
-    await dm.db('plan').insert([plan]);
+    await dm.db('plan').insert(planMocks);
+    await dm.db('plan_version').insert(planVersionMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
     await dm.db('management_consideration').insert([managementConsideration]);
   });
@@ -78,7 +80,7 @@ describe('Test Management Consideration routes', () => {
         expect(res.body).toEqual({
           ...body,
           id: 2,
-          planId: 1,
+          planId: 2,
           canonicalId: res.body.id,
         });
       });
@@ -86,7 +88,7 @@ describe('Test Management Consideration routes', () => {
 
   test('Creating a management consideration on a nonexistant plan throws a 500 error', async () => {
     await request(app)
-      .post('/api/v1/plan/10/management-consideration')
+      .post('/api/v1/plan/2/management-consideration')
       .send(body)
       .expect(500);
   });
@@ -102,7 +104,7 @@ describe('Test Management Consideration routes', () => {
         expect(res.body).toEqual({
           ...body,
           id: 2,
-          planId: 1,
+          planId: 2,
           canonicalId: 2,
         });
       });
@@ -115,7 +117,7 @@ describe('Test Management Consideration routes', () => {
         expect(res.body).toEqual({
           ...body,
           id: 2,
-          planId: 1,
+          planId: 2,
           detail,
           canonicalId: 2,
         });

--- a/__tests__/api_v1/plan/management-consideration.spec.js
+++ b/__tests__/api_v1/plan/management-consideration.spec.js
@@ -75,7 +75,12 @@ describe('Test Management Consideration routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 2, planId: 1 });
+        expect(res.body).toEqual({
+          ...body,
+          id: 2,
+          planId: 1,
+          canonicalId: res.body.id,
+        });
       });
   });
 
@@ -94,7 +99,12 @@ describe('Test Management Consideration routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 2, planId: 1 });
+        expect(res.body).toEqual({
+          ...body,
+          id: 2,
+          planId: 1,
+          canonicalId: 2,
+        });
       });
 
     await request(app)
@@ -102,7 +112,13 @@ describe('Test Management Consideration routes', () => {
       .send({ ...body, detail })
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 2, planId: 1, detail });
+        expect(res.body).toEqual({
+          ...body,
+          id: 2,
+          planId: 1,
+          detail,
+          canonicalId: 2,
+        });
       });
   });
 

--- a/__tests__/api_v1/plan/management-consideration.spec.js
+++ b/__tests__/api_v1/plan/management-consideration.spec.js
@@ -32,6 +32,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
   await dm.db.schema.raw(truncate('plan'));
+  await dm.db.schema.raw(truncate('management_consideration'));
 };
 
 describe('Test Management Consideration routes', () => {

--- a/__tests__/api_v1/plan/minister-issue-action.spec.js
+++ b/__tests__/api_v1/plan/minister-issue-action.spec.js
@@ -90,6 +90,7 @@ describe('Test Minister Issue Action routes', () => {
         expect(res.body).toEqual({
           ...body,
           id: 2,
+          canonicalId: res.body.id,
           issueId: 1,
           noGrazeStartMonth: null,
           noGrazeStartDay: null,
@@ -116,6 +117,7 @@ describe('Test Minister Issue Action routes', () => {
           other: null,
           actionTypeId,
           id: 2,
+          canonicalId: res.body.id,
           issueId: 1,
         });
       });
@@ -137,6 +139,7 @@ describe('Test Minister Issue Action routes', () => {
           noGrazeEndMonth: null,
           noGrazeEndDay: null,
           id: 2,
+          canonicalId: res.body.id,
           issueId: 1,
         });
       });
@@ -159,6 +162,7 @@ describe('Test Minister Issue Action routes', () => {
           ...body,
           id: 1,
           issueId: 1,
+          canonicalId: 1,
           noGrazeStartMonth: null,
           noGrazeStartDay: null,
           noGrazeEndMonth: null,

--- a/__tests__/api_v1/plan/minister-issue-action.spec.js
+++ b/__tests__/api_v1/plan/minister-issue-action.spec.js
@@ -92,7 +92,6 @@ describe('Test Minister Issue Action routes', () => {
         expect(res.body).toEqual({
           ...body,
           id: 2,
-          canonicalId: res.body.id,
           issueId: 1,
           noGrazeStartMonth: null,
           noGrazeStartDay: null,
@@ -119,7 +118,6 @@ describe('Test Minister Issue Action routes', () => {
           other: null,
           actionTypeId,
           id: 2,
-          canonicalId: res.body.id,
           issueId: 1,
         });
       });
@@ -141,7 +139,6 @@ describe('Test Minister Issue Action routes', () => {
           noGrazeEndMonth: null,
           noGrazeEndDay: null,
           id: 2,
-          canonicalId: res.body.id,
           issueId: 1,
         });
       });
@@ -164,7 +161,6 @@ describe('Test Minister Issue Action routes', () => {
           ...body,
           id: 1,
           issueId: 1,
-          canonicalId: 1,
           noGrazeStartMonth: null,
           noGrazeStartDay: null,
           noGrazeEndMonth: null,

--- a/__tests__/api_v1/plan/minister-issue-action.spec.js
+++ b/__tests__/api_v1/plan/minister-issue-action.spec.js
@@ -7,6 +7,7 @@ import agreementMocks from '../../../__mocks__/fixtures/agreement_mock.json';
 import issueMocks from '../../../__mocks__/fixtures/minister_issue_mock.json';
 import issueActionMocks from '../../../__mocks__/fixtures/minister_issue_action_mock.json';
 import planMocks from '../../../__mocks__/fixtures/plan_mock.json';
+import planVersionMocks from '../../../__mocks__/fixtures/plan_version_mock.json';
 import pastureMocks from '../../../__mocks__/fixtures/pasture_mock.json';
 import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../../__mocks__/fixtures/plan_confirmation_mock.json';
@@ -36,6 +37,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('ref_zone'));
   await dm.db.schema.raw(truncate('agreement'));
   await dm.db.schema.raw(truncate('client_agreement'));
+  await dm.db.schema.raw(truncate('plan_version'));
   await dm.db.schema.raw(truncate('plan'));
   await dm.db.schema.raw(truncate('plan_confirmation'));
   await dm.db.schema.raw(truncate('pasture'));
@@ -58,7 +60,6 @@ describe('Test Minister Issue Action routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
-    const plan = planMocks[0];
     const pasture = pastureMocks[0];
     const issue = issueMocks[0];
     const issueAction = issueActionMocks[0];
@@ -68,7 +69,8 @@ describe('Test Minister Issue Action routes', () => {
     await dm.db('ref_zone').insert([zone]);
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
-    await dm.db('plan').insert([plan]);
+    await dm.db('plan').insert(planMocks);
+    await dm.db('plan_version').insert(planVersionMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
     await dm.db('pasture').insert([pasture]);
     await dm.db('minister_issue').insert([issue]);
@@ -147,7 +149,7 @@ describe('Test Minister Issue Action routes', () => {
 
   test('Creating a minister issue action on a nonexistant minister issue throws a 500 error', async () => {
     await request(app)
-      .post('/api/v1/plan/1/issue/10/action')
+      .post('/api/v1/plan/1/issue/2/action')
       .send(body)
       .expect(500);
   });

--- a/__tests__/api_v1/plan/minister-issue.spec.js
+++ b/__tests__/api_v1/plan/minister-issue.spec.js
@@ -81,7 +81,12 @@ describe('Test Minister Issue routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 2, planId: 1 });
+        expect(res.body).toEqual({
+          ...body,
+          id: 2,
+          planId: 1,
+          canonicalId: res.body.id,
+        });
       });
   });
 
@@ -98,7 +103,12 @@ describe('Test Minister Issue routes', () => {
       .send(body)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, id: 1, planId: 1 });
+        expect(res.body).toEqual({
+          ...body,
+          id: 1,
+          planId: 1,
+          canonicalId: 1,
+        });
       });
   });
 

--- a/__tests__/api_v1/plan/minister-issue.spec.js
+++ b/__tests__/api_v1/plan/minister-issue.spec.js
@@ -6,6 +6,7 @@ import zoneMocks from '../../../__mocks__/fixtures/ref_zone_mock.json';
 import agreementMocks from '../../../__mocks__/fixtures/agreement_mock.json';
 import issueMocks from '../../../__mocks__/fixtures/minister_issue_mock.json';
 import planMocks from '../../../__mocks__/fixtures/plan_mock.json';
+import planVersionMocks from '../../../__mocks__/fixtures/plan_version_mock.json';
 import pastureMocks from '../../../__mocks__/fixtures/pasture_mock.json';
 import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../../__mocks__/fixtures/plan_confirmation_mock.json';
@@ -33,6 +34,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('ref_zone'));
   await dm.db.schema.raw(truncate('agreement'));
   await dm.db.schema.raw(truncate('client_agreement'));
+  await dm.db.schema.raw(truncate('plan_version'));
   await dm.db.schema.raw(truncate('plan'));
   await dm.db.schema.raw(truncate('plan_confirmation'));
   await dm.db.schema.raw(truncate('pasture'));
@@ -54,7 +56,6 @@ describe('Test Minister Issue routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
-    const plan = planMocks[0];
     const pasture = pastureMocks[0];
     const issue = issueMocks[0];
     const clientAgreement = clientAgreementMocks[0];
@@ -63,7 +64,8 @@ describe('Test Minister Issue routes', () => {
     await dm.db('ref_zone').insert([zone]);
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
-    await dm.db('plan').insert([plan]);
+    await dm.db('plan').insert(planMocks);
+    await dm.db('plan_version').insert(planVersionMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
     await dm.db('pasture').insert([pasture]);
     await dm.db('minister_issue').insert([issue]);
@@ -84,7 +86,7 @@ describe('Test Minister Issue routes', () => {
         expect(res.body).toEqual({
           ...body,
           id: 2,
-          planId: 1,
+          planId: 2,
           canonicalId: res.body.id,
         });
       });
@@ -92,7 +94,7 @@ describe('Test Minister Issue routes', () => {
 
   test('Creating a minister issue on a nonexistant plan should throw a 500 error', async () => {
     await request(app)
-      .post('/api/v1/plan/10/issue')
+      .post('/api/v1/plan/2/issue')
       .send(body)
       .expect(500);
   });
@@ -106,7 +108,7 @@ describe('Test Minister Issue routes', () => {
         expect(res.body).toEqual({
           ...body,
           id: 1,
-          planId: 1,
+          planId: 2,
           canonicalId: 1,
         });
       });

--- a/__tests__/api_v1/plan/minister-issue.spec.js
+++ b/__tests__/api_v1/plan/minister-issue.spec.js
@@ -87,7 +87,6 @@ describe('Test Minister Issue routes', () => {
           ...body,
           id: 2,
           planId: 2,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -109,7 +108,6 @@ describe('Test Minister Issue routes', () => {
           ...body,
           id: 1,
           planId: 2,
-          canonicalId: 1,
         });
       });
   });

--- a/__tests__/api_v1/plan/pasture.spec.js
+++ b/__tests__/api_v1/plan/pasture.spec.js
@@ -149,8 +149,8 @@ describe('Test Pasture routes', () => {
         });
       });
 
-    expect(await dm.db('pasture').where({ plan_id: 1 })).toHaveLength(1);
-    expect(await dm.db('pasture').where({ plan_id: 2 })).toHaveLength(1);
+    expect(await dm.db('pasture').where({ plan_id: 1 })).toHaveLength(0);
+    expect(await dm.db('pasture').where({ plan_id: 2 })).toHaveLength(2);
   });
 
   test('Trying to create a pasture with an already-used id should throw a 500 error', async () => {
@@ -165,23 +165,17 @@ describe('Test Pasture routes', () => {
 
     const planId = 2;
 
-    await dm.db('pasture')
-      .insert({ ...pastureMocks[0], plan_id: planId });
-
     await request(app)
       .put(`${baseUrl}/1`)
       .send({ ...pastureBody, name })
       .expect(200)
       .expect((res) => {
         const results = res.body;
-        expect(results.id).toEqual(2);
+        expect(results.id).toEqual(1);
         expect(results.name).toEqual(name);
         expect(results.canonicalId).toEqual(1);
         expect(results.planId).toEqual(planId);
       });
-
-    const [otherPasture] = await dm.db('pasture').where({ id: 1 });
-    expect(otherPasture.name).not.toEqual(name);
   });
 
   test('Creating a plant community', async () => {
@@ -229,16 +223,7 @@ describe('Test Pasture routes', () => {
   });
 
   test('Updating a plant community', async () => {
-    const name = 'My plant community';
-    const id = 4;
-    const planId = 2;
-
-    const [pastureId] = await dm.db('pasture')
-      .insert({ ...pastureMocks[0], plan_id: planId })
-      .returning('id');
-
-    await dm.db('plant_community')
-      .insert({ ...plantCommunityMocks[0], pasture_id: pastureId, id });
+    const name = 'My updated plant community';
 
     await request(app)
       .put(`${baseUrl}/1/plant-community/1`)
@@ -246,14 +231,11 @@ describe('Test Pasture routes', () => {
       .expect(200)
       .expect((res) => {
         const results = res.body;
-        expect(results.id).toEqual(id);
+        expect(results.id).toEqual(1);
         expect(results.name).toEqual(name);
         expect(results.canonicalId).toEqual(1);
-        expect(results.pastureId).toEqual(pastureId);
+        expect(results.pastureId).toEqual(1);
       });
-
-    const [otherPlantCommunity] = await dm.db('plant_community').where({ id: 1 });
-    expect(otherPlantCommunity.name).not.toEqual(name);
   });
 
   test('Updating a non-existant plant community throws a 404 error', async () => {

--- a/__tests__/api_v1/plan/pasture.spec.js
+++ b/__tests__/api_v1/plan/pasture.spec.js
@@ -130,7 +130,6 @@ describe('Test Pasture routes', () => {
           ...pastureBody,
           id: 2,
           planId: 2,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -145,7 +144,6 @@ describe('Test Pasture routes', () => {
           ...pastureBody,
           id: 2,
           planId: 2,
-          canonicalId: res.body.id,
         });
       });
 
@@ -173,7 +171,6 @@ describe('Test Pasture routes', () => {
         const results = res.body;
         expect(results.id).toEqual(1);
         expect(results.name).toEqual(name);
-        expect(results.canonicalId).toEqual(1);
         expect(results.planId).toEqual(planId);
       });
   });
@@ -188,7 +185,6 @@ describe('Test Pasture routes', () => {
           ...plantCommunityBody,
           id: 2,
           pastureId: 1,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -217,7 +213,6 @@ describe('Test Pasture routes', () => {
           ...plantCommunityActionBody,
           id: 1,
           plantCommunityId: 1,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -233,7 +228,6 @@ describe('Test Pasture routes', () => {
         const results = res.body;
         expect(results.id).toEqual(1);
         expect(results.name).toEqual(name);
-        expect(results.canonicalId).toEqual(1);
         expect(results.pastureId).toEqual(1);
       });
   });
@@ -276,7 +270,6 @@ describe('Test Pasture routes', () => {
           ...indicatorPlantBody,
           id: 1,
           plantCommunityId: 1,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -314,7 +307,6 @@ describe('Test Pasture routes', () => {
           ...monitoringAreaBody,
           id: 1,
           plantCommunityId: 1,
-          canonicalId: res.body.id,
           purposes: [
             {
               canonicalId: 1,

--- a/__tests__/api_v1/plan/pasture.spec.js
+++ b/__tests__/api_v1/plan/pasture.spec.js
@@ -188,6 +188,9 @@ describe('Test Pasture routes', () => {
         expect(results.canonicalId).toEqual(1);
         expect(results.planId).toEqual(planId);
       });
+
+    const [otherPasture] = await dm.db('pasture').where({ id: 1 });
+    expect(otherPasture.name).not.toEqual(name);
   });
 
   test('Creating a plant community', async () => {

--- a/__tests__/api_v1/plan/pasture.spec.js
+++ b/__tests__/api_v1/plan/pasture.spec.js
@@ -309,7 +309,6 @@ describe('Test Pasture routes', () => {
           plantCommunityId: 1,
           purposes: [
             {
-              canonicalId: 1,
               id: 1,
               monitoringAreaId: 1,
               purposeType: {
@@ -320,7 +319,6 @@ describe('Test Pasture routes', () => {
               purposeTypeId: 1,
             },
             {
-              canonicalId: 2,
               id: 2,
               monitoringAreaId: 1,
               purposeType: {

--- a/__tests__/api_v1/plan/pasture.spec.js
+++ b/__tests__/api_v1/plan/pasture.spec.js
@@ -128,6 +128,7 @@ describe('Test Pasture routes', () => {
           ...pastureBody,
           id: 2,
           planId: 1,
+          canonicalId: res.body.id,
         });
       });
   });
@@ -150,6 +151,7 @@ describe('Test Pasture routes', () => {
         const results = res.body;
         expect(results.id).toEqual(1);
         expect(results.name).toEqual(name);
+        expect(results.canonicalId).toEqual(1);
       });
   });
 
@@ -163,6 +165,7 @@ describe('Test Pasture routes', () => {
           ...plantCommunityBody,
           id: 2,
           pastureId: 1,
+          canonicalId: res.body.id,
         });
       });
   });
@@ -191,6 +194,7 @@ describe('Test Pasture routes', () => {
           ...plantCommunityActionBody,
           id: 1,
           plantCommunityId: 1,
+          canonicalId: res.body.id,
         });
       });
   });
@@ -219,6 +223,7 @@ describe('Test Pasture routes', () => {
           ...indicatorPlantBody,
           id: 1,
           plantCommunityId: 1,
+          canonicalId: res.body.id,
         });
       });
   });
@@ -256,8 +261,10 @@ describe('Test Pasture routes', () => {
           ...monitoringAreaBody,
           id: 1,
           plantCommunityId: 1,
+          canonicalId: res.body.id,
           purposes: [
             {
+              canonicalId: 1,
               id: 1,
               monitoringAreaId: 1,
               purposeType: {
@@ -268,6 +275,7 @@ describe('Test Pasture routes', () => {
               purposeTypeId: 1,
             },
             {
+              canonicalId: 2,
               id: 2,
               monitoringAreaId: 1,
               purposeType: {

--- a/__tests__/api_v1/plan/pasture.spec.js
+++ b/__tests__/api_v1/plan/pasture.spec.js
@@ -78,6 +78,8 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
   await dm.db.schema.raw(truncate('plan'));
+  await dm.db.schema.raw(truncate('pasture'));
+  await dm.db.schema.raw(truncate('plant_community'));
 };
 
 describe('Test Pasture routes', () => {

--- a/__tests__/api_v1/plan/schedule.spec.js
+++ b/__tests__/api_v1/plan/schedule.spec.js
@@ -91,6 +91,7 @@ describe('Test Schedule routes', () => {
           ...body,
           planId: 1,
           id: 2,
+          canonicalId: res.body.id,
         });
       });
   });
@@ -109,7 +110,13 @@ describe('Test Schedule routes', () => {
       .send({ ...body, narative })
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...body, narative, id: 1, planId: 1 });
+        expect(res.body).toEqual({
+          ...body,
+          narative,
+          id: 1,
+          planId: 1,
+          canonicalId: 1,
+        });
       });
   });
 
@@ -140,7 +147,12 @@ describe('Test Schedule routes', () => {
       .send(entryBody)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...entryBody, id: 1, grazingScheduleId: 1 });
+        expect(res.body).toEqual({
+          ...entryBody,
+          id: 1,
+          grazingScheduleId: 1,
+          canonicalId: res.body.id,
+        });
       });
   });
 
@@ -157,7 +169,12 @@ describe('Test Schedule routes', () => {
       .send(entryBody)
       .expect(200)
       .expect((res) => {
-        expect(res.body).toEqual({ ...entryBody, id: 1, grazingScheduleId: 1 });
+        expect(res.body).toEqual({
+          ...entryBody,
+          id: 1,
+          grazingScheduleId: 1,
+          canonicalId: res.body.id,
+        });
       });
 
     await request(app)
@@ -177,6 +194,7 @@ describe('Test Schedule routes', () => {
         expect(res.body.grazingScheduleEntries[0]).toEqual({
           ...entryBody,
           id: 1,
+          canonicalId: res.body.id,
           grazingScheduleId: 1,
           livestockType: {
             active: true,

--- a/__tests__/api_v1/plan/schedule.spec.js
+++ b/__tests__/api_v1/plan/schedule.spec.js
@@ -41,6 +41,8 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
   await dm.db.schema.raw(truncate('plan'));
+  await dm.db.schema.raw(truncate('pasture'));
+  await dm.db.schema.raw(truncate('grazing_schedule'));
 };
 
 describe('Test Schedule routes', () => {

--- a/__tests__/api_v1/plan/schedule.spec.js
+++ b/__tests__/api_v1/plan/schedule.spec.js
@@ -5,6 +5,7 @@ import userMocks from '../../../__mocks__/fixtures/user_account_mock.json';
 import zoneMocks from '../../../__mocks__/fixtures/ref_zone_mock.json';
 import agreementMocks from '../../../__mocks__/fixtures/agreement_mock.json';
 import planMocks from '../../../__mocks__/fixtures/plan_mock.json';
+import planVersionMocks from '../../../__mocks__/fixtures/plan_version_mock.json';
 import scheduleMocks from '../../../__mocks__/fixtures/schedule_mock.json';
 import pastureMocks from '../../../__mocks__/fixtures/pasture_mock.json';
 import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
@@ -22,7 +23,6 @@ const baseUrl = '/api/v1/plan/1/schedule';
 const body = {
   year: 2021,
   narative: 'This is a narative',
-  planId: 1,
   grazingScheduleEntries: [],
 };
 const entryBody = {
@@ -41,6 +41,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
   await dm.db.schema.raw(truncate('plan'));
+  await dm.db.schema.raw(truncate('plan_version'));
   await dm.db.schema.raw(truncate('pasture'));
   await dm.db.schema.raw(truncate('grazing_schedule'));
 };
@@ -60,7 +61,6 @@ describe('Test Schedule routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
-    const plan = planMocks[0];
     const schedule = scheduleMocks[0];
     const pasture = pastureMocks[0];
     const clientAgreement = clientAgreementMocks[0];
@@ -69,7 +69,8 @@ describe('Test Schedule routes', () => {
     await dm.db('ref_zone').insert([zone]);
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
-    await dm.db('plan').insert([plan]);
+    await dm.db('plan').insert(planMocks);
+    await dm.db('plan_version').insert(planVersionMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
     await dm.db('grazing_schedule').insert([schedule]);
     await dm.db('pasture').insert([pasture]);
@@ -89,7 +90,7 @@ describe('Test Schedule routes', () => {
       .expect((res) => {
         expect(res.body).toEqual({
           ...body,
-          planId: 1,
+          planId: 2,
           id: 2,
           canonicalId: res.body.id,
         });
@@ -98,7 +99,7 @@ describe('Test Schedule routes', () => {
 
   test('Creating a schedule with for a nonexistant plan throws a 500 error', async () => {
     await request(app)
-      .post('/api/v1/plan/10/schedule')
+      .post('/api/v1/plan/2/schedule')
       .send(body)
       .expect(500);
   });
@@ -114,7 +115,7 @@ describe('Test Schedule routes', () => {
           ...body,
           narative,
           id: 1,
-          planId: 1,
+          planId: 2,
           canonicalId: 1,
         });
       });

--- a/__tests__/api_v1/plan/schedule.spec.js
+++ b/__tests__/api_v1/plan/schedule.spec.js
@@ -92,7 +92,6 @@ describe('Test Schedule routes', () => {
           ...body,
           planId: 2,
           id: 2,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -116,7 +115,6 @@ describe('Test Schedule routes', () => {
           narative,
           id: 1,
           planId: 2,
-          canonicalId: 1,
         });
       });
   });
@@ -152,7 +150,6 @@ describe('Test Schedule routes', () => {
           ...entryBody,
           id: 1,
           grazingScheduleId: 1,
-          canonicalId: res.body.id,
         });
       });
   });
@@ -174,7 +171,6 @@ describe('Test Schedule routes', () => {
           ...entryBody,
           id: 1,
           grazingScheduleId: 1,
-          canonicalId: res.body.id,
         });
       });
 
@@ -195,7 +191,6 @@ describe('Test Schedule routes', () => {
         expect(res.body.grazingScheduleEntries[0]).toEqual({
           ...entryBody,
           id: 1,
-          canonicalId: res.body.id,
           grazingScheduleId: 1,
           livestockType: {
             active: true,

--- a/__tests__/api_v1/plan/version.spec.js
+++ b/__tests__/api_v1/plan/version.spec.js
@@ -77,7 +77,6 @@ describe('Test Plan routes', () => {
     const user = userMocks[0];
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
-    const plan = planMocks[0];
     const pasture = pastureMocks[0];
     const plantCommunity = plantCommunityMocks[0];
     const plantCommunityAction = plantCommunityActionMocks[0];
@@ -97,7 +96,7 @@ describe('Test Plan routes', () => {
     await dm.db('ref_zone').insert([zone]);
     await dm.db('agreement').insert([agreement]);
     await dm.db('client_agreement').insert([clientAgreement]);
-    await dm.db('plan').insert([plan]);
+    await dm.db('plan').insert(planMocks);
     await dm.db('plan_version').insert(planVersionMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
     await dm.db('pasture').insert([pasture]);
@@ -136,7 +135,7 @@ describe('Test Plan routes', () => {
     // canonical ID
     const planId = 1;
 
-    const [originalPlan] = await dm.db('plan');
+    const [originalPlan] = await dm.db('plan').where({ id: 2 });
 
     await request(app)
       .post(baseUrl)
@@ -152,7 +151,7 @@ describe('Test Plan routes', () => {
 
     const [newVersion] = await dm.db('plan_version')
       .where('canonical_id', planId)
-      .where('version', 3);
+      .where('version', 2);
 
     expect(newVersion.plan_id).toEqual(originalPlan.id);
     expect(newVersion.canonical_id).toEqual(planId);
@@ -160,7 +159,7 @@ describe('Test Plan routes', () => {
 
     expect(
       await dm.db('plan'),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
   });
 
   test('Throws a 404 error if the plan does not exist with that canonical ID', async () => {
@@ -195,7 +194,7 @@ describe('Test Plan routes', () => {
     const ministerIssuePastures = await dm.db('minister_issue_pasture');
     const managementConsiderations = await dm.db('management_consideration');
 
-    expect(plans).toHaveLength(2);
+    expect(plans).toHaveLength(3);
     expect(pastures).toHaveLength(2);
     expect(plantCommunities).toHaveLength(2);
     expect(indicatorPlants).toHaveLength(2);

--- a/__tests__/api_v1/plan/version.spec.js
+++ b/__tests__/api_v1/plan/version.spec.js
@@ -1,0 +1,129 @@
+import { default as request } from 'supertest'; // eslint-disable-line
+import passport from 'passport';
+import app from '../../../src';
+import userMocks from '../../../__mocks__/fixtures/user_account_mock.json';
+import zoneMocks from '../../../__mocks__/fixtures/ref_zone_mock.json';
+import agreementMocks from '../../../__mocks__/fixtures/agreement_mock.json';
+import planMocks from '../../../__mocks__/fixtures/plan_mock.json';
+import planVersionMocks from '../../../__mocks__/fixtures/plan_version_mock.json';
+import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
+import planConfirmationMocks from '../../../__mocks__/fixtures/plan_confirmation_mock.json';
+import DataManager from '../../../src/libs/db2';
+import config from '../../../src/config';
+
+const dm = new DataManager(config);
+
+jest.mock('request-promise-native');
+
+
+const { canAccessAgreement } = passport.aUser;
+const truncate = table => `TRUNCATE TABLE ${table} RESTART IDENTITY CASCADE`;
+const baseUrl = '/api/v1/plan/1/version';
+const body = {
+  planId: 1,
+};
+
+const truncateTables = async () => {
+  await dm.db.schema.raw(truncate('user_account'));
+  await dm.db.schema.raw(truncate('ref_zone'));
+  await dm.db.schema.raw(truncate('plan_confirmation'));
+  await dm.db.schema.raw(truncate('client_agreement'));
+  await dm.db.schema.raw(truncate('agreement'));
+  await dm.db.schema.raw(truncate('plan'));
+  await dm.db.schema.raw(truncate('plan_version'));
+};
+
+describe('Test Plan routes', () => {
+  beforeAll(async () => {
+    passport.aUser.isAgreementHolder = () => false;
+    passport.aUser.isRangeOfficer = () => false;
+    passport.aUser.isAdministrator = () => true;
+
+    await truncateTables();
+  });
+
+  beforeEach(async () => {
+    passport.aUser.canAccessAgreement = () => true;
+
+    const user = userMocks[0];
+    const zone = zoneMocks[0];
+    const agreement = agreementMocks[0];
+    const plan = planMocks[0];
+    const clientAgreement = clientAgreementMocks[0];
+    const planConfirmation = planConfirmationMocks[0];
+    await dm.db('user_account').insert([user]);
+    await dm.db('ref_zone').insert([zone]);
+    await dm.db('agreement').insert([agreement]);
+    await dm.db('client_agreement').insert([clientAgreement]);
+    await dm.db('plan').insert([plan]);
+    await dm.db('plan_version').insert(planVersionMocks);
+    await dm.db('plan_confirmation').insert([planConfirmation]);
+  });
+
+  afterEach(async () => {
+    passport.aUser.canAccessAgreement = canAccessAgreement;
+
+    await truncateTables();
+  });
+
+  describe('Creating a new version', () => {
+    test('Creating a new version', async () => {
+      const planId = 1;
+      await request(app)
+        .post(baseUrl)
+        .send({ ...body, planId })
+        .expect(200);
+    });
+
+    test('It creates a new version', async () => {
+      const planId = 1;
+      await request(app)
+        .post(baseUrl)
+        .send({ ...body, planId })
+        .expect(200);
+
+      const versions = await dm.db('plan_version').where('canonical_id', planId);
+      expect(versions).toHaveLength(planVersionMocks.length + 1);
+    });
+
+    test('It modifies the current version record to point to a newly created plan', async () => {
+      // canonical ID
+      const planId = 1;
+
+      const [originalPlan] = await dm.db('plan');
+
+      await request(app)
+        .post(baseUrl)
+        .send({ ...body, planId })
+        .expect(200);
+
+      const [currentVersion] = await dm.db('plan_version')
+        .where('canonical_id', planId)
+        .where('version', -1);
+
+      expect(currentVersion.plan_id).not.toEqual(originalPlan.id);
+      expect(currentVersion.canonical_id).toEqual(planId);
+
+      const [newVersion] = await dm.db('plan_version')
+        .where('canonical_id', planId)
+        .where('version', 3);
+
+      expect(newVersion.plan_id).toEqual(originalPlan.id);
+      expect(newVersion.canonical_id).toEqual(planId);
+
+
+      expect(
+        await dm.db('plan'),
+      ).toHaveLength(2);
+    });
+
+    test('Throws a 404 error if the plan does not exist with that canonical ID', async () => {
+      const planId = 5;
+
+      await request(app)
+        .post(baseUrl)
+        .send({ planId })
+        .expect(404);
+    });
+  });
+});

--- a/__tests__/api_v1/plan/version.spec.js
+++ b/__tests__/api_v1/plan/version.spec.js
@@ -19,6 +19,7 @@ import ministerIssueMocks from '../../../__mocks__/fixtures/minister_issue_mock.
 import ministerIssueActionMocks from '../../../__mocks__/fixtures/minister_issue_action_mock.json';
 import ministerIssuePastureMocks from '../../../__mocks__/fixtures/minister_issue_pasture_mock.json';
 import managementConsiderationMocks from '../../../__mocks__/fixtures/management_consideration_mock.json';
+import invasivePlantMocks from '../../../__mocks__/fixtures/invasive_plant_mock.json'
 import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../../__mocks__/fixtures/plan_confirmation_mock.json';
 import DataManager from '../../../src/libs/db2';
@@ -55,6 +56,7 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('plant_community'));
   await dm.db.schema.raw(truncate('plant_community_action'));
   await dm.db.schema.raw(truncate('pasture'));
+  await dm.db.schema.raw(truncate('invasive_plant_checklist'));
   await dm.db.schema.raw(truncate('plan'));
   await dm.db.schema.raw(truncate('plan_version'));
 };
@@ -112,6 +114,7 @@ describe('Test Plan routes', () => {
     await dm.db('minister_issue_action').insert([ministerIssueAction]);
     await dm.db('minister_issue_pasture').insert([ministerIssuePasture]);
     await dm.db('management_consideration').insert([managementConsideration]);
+    await dm.db('invasive_plant_checklist').insert(invasivePlantMocks);
   });
 
   afterEach(async () => {

--- a/__tests__/api_v1/plan/version.spec.js
+++ b/__tests__/api_v1/plan/version.spec.js
@@ -6,6 +6,19 @@ import zoneMocks from '../../../__mocks__/fixtures/ref_zone_mock.json';
 import agreementMocks from '../../../__mocks__/fixtures/agreement_mock.json';
 import planMocks from '../../../__mocks__/fixtures/plan_mock.json';
 import planVersionMocks from '../../../__mocks__/fixtures/plan_version_mock.json';
+import pastureMocks from '../../../__mocks__/fixtures/pasture_mock.json';
+import plantCommunityMocks from '../../../__mocks__/fixtures/plant_community_mock.json';
+import plantCommunityActionMocks from '../../../__mocks__/fixtures/plant_community_action_mock.json';
+import indicatorPlantMocks from '../../../__mocks__/fixtures/indicator_plant_mock.json';
+import monitoringAreaMocks from '../../../__mocks__/fixtures/monitoring_area_mock.json';
+import monitoringAreaPurposeMocks from '../../../__mocks__/fixtures/monitoring_area_purpose_mock.json';
+import grazingScheduleMocks from '../../../__mocks__/fixtures/schedule_mock.json';
+import grazingScheduleEntryMocks from '../../../__mocks__/fixtures/schedule_entry_mock.json';
+import additionalRequirementMocks from '../../../__mocks__/fixtures/additional_requirement_mock.json';
+import ministerIssueMocks from '../../../__mocks__/fixtures/minister_issue_mock.json';
+import ministerIssueActionMocks from '../../../__mocks__/fixtures/minister_issue_action_mock.json';
+import ministerIssuePastureMocks from '../../../__mocks__/fixtures/minister_issue_pasture_mock.json';
+import managementConsiderationMocks from '../../../__mocks__/fixtures/management_consideration_mock.json';
 import clientAgreementMocks from '../../../__mocks__/fixtures/client_agreement_mock.json';
 import planConfirmationMocks from '../../../__mocks__/fixtures/plan_confirmation_mock.json';
 import DataManager from '../../../src/libs/db2';
@@ -29,9 +42,25 @@ const truncateTables = async () => {
   await dm.db.schema.raw(truncate('plan_confirmation'));
   await dm.db.schema.raw(truncate('client_agreement'));
   await dm.db.schema.raw(truncate('agreement'));
+  await dm.db.schema.raw(truncate('management_consideration'));
+  await dm.db.schema.raw(truncate('minister_issue_pasture'));
+  await dm.db.schema.raw(truncate('minister_issue_action'));
+  await dm.db.schema.raw(truncate('minister_issue'));
+  await dm.db.schema.raw(truncate('additional_requirement'));
+  await dm.db.schema.raw(truncate('grazing_schedule_entry'));
+  await dm.db.schema.raw(truncate('grazing_schedule'));
+  await dm.db.schema.raw(truncate('monitoring_area_purpose'));
+  await dm.db.schema.raw(truncate('monitoring_area'));
+  await dm.db.schema.raw(truncate('indicator_plant'));
+  await dm.db.schema.raw(truncate('plant_community'));
+  await dm.db.schema.raw(truncate('plant_community_action'));
+  await dm.db.schema.raw(truncate('pasture'));
   await dm.db.schema.raw(truncate('plan'));
   await dm.db.schema.raw(truncate('plan_version'));
 };
+
+const hasSameCanonicalID = rows =>
+  rows.some(r => r.canonical_id === rows[0].canonical_id);
 
 describe('Test Plan routes', () => {
   beforeAll(async () => {
@@ -49,6 +78,19 @@ describe('Test Plan routes', () => {
     const zone = zoneMocks[0];
     const agreement = agreementMocks[0];
     const plan = planMocks[0];
+    const pasture = pastureMocks[0];
+    const plantCommunity = plantCommunityMocks[0];
+    const plantCommunityAction = plantCommunityActionMocks[0];
+    const indicatorPlant = indicatorPlantMocks[0];
+    const monitoringArea = monitoringAreaMocks[0];
+    const monitoringAreaPurpose = monitoringAreaPurposeMocks[0];
+    const grazingSchedule = grazingScheduleMocks[0];
+    const grazingScheduleEntry = grazingScheduleEntryMocks[0];
+    const additionalRequirement = additionalRequirementMocks[0];
+    const ministerIssue = ministerIssueMocks[0];
+    const ministerIssueAction = ministerIssueActionMocks[0];
+    const ministerIssuePasture = ministerIssuePastureMocks[0];
+    const managementConsideration = managementConsiderationMocks[0];
     const clientAgreement = clientAgreementMocks[0];
     const planConfirmation = planConfirmationMocks[0];
     await dm.db('user_account').insert([user]);
@@ -58,6 +100,19 @@ describe('Test Plan routes', () => {
     await dm.db('plan').insert([plan]);
     await dm.db('plan_version').insert(planVersionMocks);
     await dm.db('plan_confirmation').insert([planConfirmation]);
+    await dm.db('pasture').insert([pasture]);
+    await dm.db('plant_community').insert([plantCommunity]);
+    await dm.db('plant_community_action').insert([plantCommunityAction]);
+    await dm.db('indicator_plant').insert([indicatorPlant]);
+    await dm.db('monitoring_area').insert([monitoringArea]);
+    await dm.db('monitoring_area_purpose').insert([monitoringAreaPurpose]);
+    await dm.db('grazing_schedule').insert([grazingSchedule]);
+    await dm.db('grazing_schedule_entry').insert([grazingScheduleEntry]);
+    await dm.db('additional_requirement').insert([additionalRequirement]);
+    await dm.db('minister_issue').insert([ministerIssue]);
+    await dm.db('minister_issue_action').insert([ministerIssueAction]);
+    await dm.db('minister_issue_pasture').insert([ministerIssuePasture]);
+    await dm.db('management_consideration').insert([managementConsideration]);
   });
 
   afterEach(async () => {
@@ -66,64 +121,108 @@ describe('Test Plan routes', () => {
     await truncateTables();
   });
 
-  describe('Creating a new version', () => {
-    test('Creating a new version', async () => {
-      const planId = 1;
-      await request(app)
-        .post(baseUrl)
-        .send({ ...body, planId })
-        .expect(200);
-    });
+  test('Creating a new version', async () => {
+    const planId = 1;
+    await request(app)
+      .post(baseUrl)
+      .send({ ...body, planId })
+      .expect(200);
 
-    test('It creates a new version', async () => {
-      const planId = 1;
-      await request(app)
-        .post(baseUrl)
-        .send({ ...body, planId })
-        .expect(200);
+    const versions = await dm.db('plan_version').where('canonical_id', planId);
+    expect(versions).toHaveLength(planVersionMocks.length + 1);
+  });
 
-      const versions = await dm.db('plan_version').where('canonical_id', planId);
-      expect(versions).toHaveLength(planVersionMocks.length + 1);
-    });
+  test('Creating a new version modifies the current version record to point to a newly created plan', async () => {
+    // canonical ID
+    const planId = 1;
 
-    test('It modifies the current version record to point to a newly created plan', async () => {
-      // canonical ID
-      const planId = 1;
+    const [originalPlan] = await dm.db('plan');
 
-      const [originalPlan] = await dm.db('plan');
+    await request(app)
+      .post(baseUrl)
+      .send({ ...body, planId })
+      .expect(200);
 
-      await request(app)
-        .post(baseUrl)
-        .send({ ...body, planId })
-        .expect(200);
+    const [currentVersion] = await dm.db('plan_version')
+      .where('canonical_id', planId)
+      .where('version', -1);
 
-      const [currentVersion] = await dm.db('plan_version')
-        .where('canonical_id', planId)
-        .where('version', -1);
+    expect(currentVersion.plan_id).not.toEqual(originalPlan.id);
+    expect(currentVersion.canonical_id).toEqual(planId);
 
-      expect(currentVersion.plan_id).not.toEqual(originalPlan.id);
-      expect(currentVersion.canonical_id).toEqual(planId);
+    const [newVersion] = await dm.db('plan_version')
+      .where('canonical_id', planId)
+      .where('version', 3);
 
-      const [newVersion] = await dm.db('plan_version')
-        .where('canonical_id', planId)
-        .where('version', 3);
-
-      expect(newVersion.plan_id).toEqual(originalPlan.id);
-      expect(newVersion.canonical_id).toEqual(planId);
+    expect(newVersion.plan_id).toEqual(originalPlan.id);
+    expect(newVersion.canonical_id).toEqual(planId);
 
 
-      expect(
-        await dm.db('plan'),
-      ).toHaveLength(2);
-    });
+    expect(
+      await dm.db('plan'),
+    ).toHaveLength(2);
+  });
 
-    test('Throws a 404 error if the plan does not exist with that canonical ID', async () => {
-      const planId = 5;
+  test('Throws a 404 error if the plan does not exist with that canonical ID', async () => {
+    const planId = 5;
 
-      await request(app)
-        .post(baseUrl)
-        .send({ planId })
-        .expect(404);
-    });
+    await request(app)
+      .post(baseUrl)
+      .send({ planId })
+      .expect(404);
+  });
+
+  test('Duplicates all existing records for a plan, keeping the canonical IDs the same', async () => {
+    const planId = 1;
+    await request(app)
+      .post(baseUrl)
+      .send({ ...body, planId })
+      .expect(200);
+
+
+    const plans = await dm.db('plan');
+    const pastures = await dm.db('pasture');
+    const plantCommunities = await dm.db('plant_community');
+    const indicatorPlants = await dm.db('indicator_plant');
+    const monitoringAreas = await dm.db('monitoring_area');
+    const monitoringAreaPurposes = await dm.db('monitoring_area_purpose');
+    const plantCommunityActions = await dm.db('plant_community_action');
+    const grazingSchedules = await dm.db('grazing_schedule');
+    const grazingScheduleEntries = await dm.db('grazing_schedule_entry');
+    const additionalRequirements = await dm.db('additional_requirement');
+    const ministerIssues = await dm.db('minister_issue');
+    const ministerIssueActions = await dm.db('minister_issue_action');
+    const ministerIssuePastures = await dm.db('minister_issue_pasture');
+    const managementConsiderations = await dm.db('management_consideration');
+
+    expect(plans).toHaveLength(2);
+    expect(pastures).toHaveLength(2);
+    expect(plantCommunities).toHaveLength(2);
+    expect(indicatorPlants).toHaveLength(2);
+    expect(monitoringAreas).toHaveLength(2);
+    expect(monitoringAreaPurposes).toHaveLength(2);
+    expect(plantCommunityActions).toHaveLength(2);
+    expect(grazingSchedules).toHaveLength(2);
+    expect(grazingScheduleEntries).toHaveLength(2);
+    expect(additionalRequirements).toHaveLength(2);
+    expect(ministerIssues).toHaveLength(2);
+    expect(ministerIssueActions).toHaveLength(2);
+    expect(ministerIssuePastures).toHaveLength(2);
+    expect(managementConsiderations).toHaveLength(2);
+
+    expect(hasSameCanonicalID(plans)).toBeTruthy();
+    expect(hasSameCanonicalID(pastures)).toBeTruthy();
+    expect(hasSameCanonicalID(plantCommunities)).toBeTruthy();
+    expect(hasSameCanonicalID(indicatorPlants)).toBeTruthy();
+    expect(hasSameCanonicalID(monitoringAreas)).toBeTruthy();
+    expect(hasSameCanonicalID(monitoringAreaPurposes)).toBeTruthy();
+    expect(hasSameCanonicalID(plantCommunityActions)).toBeTruthy();
+    expect(hasSameCanonicalID(grazingSchedules)).toBeTruthy();
+    expect(hasSameCanonicalID(grazingScheduleEntries)).toBeTruthy();
+    expect(hasSameCanonicalID(additionalRequirements)).toBeTruthy();
+    expect(hasSameCanonicalID(ministerIssues)).toBeTruthy();
+    expect(hasSameCanonicalID(ministerIssueActions)).toBeTruthy();
+    expect(hasSameCanonicalID(ministerIssuePastures)).toBeTruthy();
+    expect(hasSameCanonicalID(managementConsiderations)).toBeTruthy();
   });
 });

--- a/__tests__/api_v1/plan/version.spec.js
+++ b/__tests__/api_v1/plan/version.spec.js
@@ -127,7 +127,6 @@ describe('Test Plan routes', () => {
     const planId = 1;
     await request(app)
       .post(baseUrl)
-      .send({ ...body, planId })
       .expect(200);
 
     const versions = await dm.db('plan_version').where('canonical_id', planId);
@@ -142,7 +141,6 @@ describe('Test Plan routes', () => {
 
     await request(app)
       .post(baseUrl)
-      .send({ ...body, planId })
       .expect(200);
 
     const [currentVersion] = await dm.db('plan_version')
@@ -166,19 +164,14 @@ describe('Test Plan routes', () => {
   });
 
   test('Throws a 404 error if the plan does not exist with that canonical ID', async () => {
-    const planId = 5;
-
     await request(app)
-      .post(baseUrl)
-      .send({ planId })
+      .post('/api/v1/plan/10/version')
       .expect(404);
   });
 
   test('Duplicates all existing records for a plan, keeping the canonical IDs the same', async () => {
-    const planId = 1;
     await request(app)
       .post(baseUrl)
-      .send({ ...body, planId })
       .expect(200);
 
 

--- a/src/libs/db2/index.js
+++ b/src/libs/db2/index.js
@@ -28,6 +28,7 @@ import LivestockIdentifierType from './model/livestockidentifiertype';
 import LivestockType from './model/livestocktype';
 import Pasture from './model/pasture';
 import Plan from './model/plan';
+import PlanVersion from './model/planversion';
 import PlanExtension from './model/planextension';
 import PlanStatus from './model/planstatus';
 import Usage from './model/usage';
@@ -105,6 +106,7 @@ export default class DataManager {
     this.MinisterIssueType = MinisterIssueType;
     this.MinisterIssuePasture = MinisterIssuePasture;
     this.Plan = Plan;
+    this.PlanVersion = PlanVersion;
     this.PlanStatus = PlanStatus;
     this.PlanExtension = PlanExtension;
     this.Pasture = Pasture;

--- a/src/libs/db2/migrations/20191023085607_add-canonical_id-column.js
+++ b/src/libs/db2/migrations/20191023085607_add-canonical_id-column.js
@@ -13,6 +13,7 @@ const tables = [
   'minister_issue_action',
   'minister_issue_pasture',
   'management_consideration',
+  'invasive_plant_checklist',
 ];
 
 exports.up = async (knex) => {

--- a/src/libs/db2/migrations/20191023085607_add-canonical_id-column.js
+++ b/src/libs/db2/migrations/20191023085607_add-canonical_id-column.js
@@ -1,0 +1,36 @@
+const tables = [
+  'plan',
+  'pasture',
+  'plant_community',
+  'indicator_plant',
+  'monitoring_area',
+  'monitoring_area_purpose',
+  'plant_community_action',
+  'grazing_schedule',
+  'grazing_schedule_entry',
+  'additional_requirement',
+  'minister_issue',
+  'minister_issue_action',
+  'minister_issue_pasture',
+  'management_consideration',
+];
+
+exports.up = async (knex) => {
+  const promises = tables.map(async (table) => {
+    await knex.raw(`ALTER TABLE ${table} ADD canonical_id INTEGER;`);
+    await knex.raw(`UPDATE ${table} SET canonical_id = id;`);
+  });
+
+  await Promise.all(promises);
+};
+
+exports.down = async (knex) => {
+  const promises = tables.map(async (table) => {
+    knex.schema.alterTable(table, (t) => {
+      t.dropColumn('version');
+    });
+  });
+
+  await Promise.all(promises);
+};
+

--- a/src/libs/db2/migrations/20191023143720_create-plan-version.js
+++ b/src/libs/db2/migrations/20191023143720_create-plan-version.js
@@ -1,0 +1,13 @@
+exports.up = async (knex) => {
+  await knex.raw(`
+  CREATE TABLE plan_version (
+    version SERIAL NOT NULL,
+    canonical_id INTEGER NOT NULL,
+    plan_id INTEGER REFERENCES plan(id),
+    PRIMARY KEY (canonical_id, version)
+  )`);
+};
+
+exports.down = async (knex) => {
+  await knex.raw('DROP TABLE plan_version');
+};

--- a/src/libs/db2/model/__mocks__/plan.js
+++ b/src/libs/db2/model/__mocks__/plan.js
@@ -47,4 +47,11 @@ export default class Plan extends Model {
     assert(where, 'Plan: find: require: where');
     return Plan.loadFixtures();
   }
+
+  static async findCurrentVersion(db, canonicalId) {
+    assert(db, 'Plan: findCurrentVersion: require: db');
+    assert(canonicalId, 'Plan: findCurrentVersion: require: canonicalId');
+
+    return Plan.loadFixtures()[0];
+  }
 }

--- a/src/libs/db2/model/additionalrequirement.js
+++ b/src/libs/db2/model/additionalrequirement.js
@@ -21,7 +21,7 @@ export default class AdditionalRequirement extends Model {
 
   static get fields() {
     // primary key *must* be first!
-    return ['id', 'detail', 'url', 'category_id', 'plan_id']
+    return ['id', 'detail', 'url', 'category_id', 'plan_id', 'canonical_id']
       .map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/grazingschedule.js
+++ b/src/libs/db2/model/grazingschedule.js
@@ -26,7 +26,7 @@ import Model from './model';
 export default class GrazingSchedule extends Model {
   static get fields() {
     // primary key *must* be first!
-    return ['id', 'year', 'narative', 'plan_id']
+    return ['id', 'year', 'narative', 'plan_id', 'canonical_id']
       .map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/grazingscheduleentry.js
+++ b/src/libs/db2/model/grazingscheduleentry.js
@@ -40,7 +40,7 @@ export default class GrazingScheduleEntry extends Model {
   static get fields() {
     // primary key *must* be first!
     return ['id', 'grace_days', 'livestock_count', 'date_in', 'date_out',
-      'pasture_id', 'livestock_type_id', 'grazing_schedule_id']
+      'pasture_id', 'livestock_type_id', 'grazing_schedule_id', 'canonical_id']
       .map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/indicatorplant.js
+++ b/src/libs/db2/model/indicatorplant.js
@@ -23,7 +23,7 @@ export default class IndicatorPlant extends Model {
     // primary key *must* be first!
     return [
       'id', 'plant_species_id', 'plant_community_id',
-      'criteria', 'value', 'name',
+      'criteria', 'value', 'name', 'canonical_id',
     ].map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/invasiveplantchecklist.js
+++ b/src/libs/db2/model/invasiveplantchecklist.js
@@ -7,7 +7,7 @@ export default class InvasivePlantChecklist extends Model {
     // primary key *must* be first!
     return [
       'id', 'plan_id', 'equipment_and_vehicles_parking', 'begin_in_uninfested_area',
-      'undercarriges_inspected', 'revegetate', 'other',
+      'undercarriges_inspected', 'revegetate', 'other', 'canonical_id',
     ].map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/managementconsideration.js
+++ b/src/libs/db2/model/managementconsideration.js
@@ -21,7 +21,7 @@ export default class ManagementConsideration extends Model {
 
   static get fields() {
     // primary key *must* be first!
-    return ['id', 'detail', 'url', 'consideration_type_id', 'plan_id']
+    return ['id', 'detail', 'url', 'consideration_type_id', 'plan_id', 'canonical_id']
       .map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/ministerissue.js
+++ b/src/libs/db2/model/ministerissue.js
@@ -43,7 +43,7 @@ export default class MinisterIssue extends Model {
 
   static get fields() {
     // primary key *must* be first!
-    return ['id', 'detail', 'objective', 'identified', 'issue_type_id', 'plan_id']
+    return ['id', 'detail', 'objective', 'identified', 'issue_type_id', 'plan_id', 'canonical_id']
       .map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/ministerissueaction.js
+++ b/src/libs/db2/model/ministerissueaction.js
@@ -47,6 +47,7 @@ export default class MinisterIssueAction extends Model {
     return [
       'id', 'detail', 'action_type_id', 'issue_id', 'other',
       'no_graze_start_day', 'no_graze_start_month', 'no_graze_end_day', 'no_graze_end_month',
+      'canonical_id',
     ].map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/ministerissuepasture.js
+++ b/src/libs/db2/model/ministerissuepasture.js
@@ -27,7 +27,7 @@ import Model from './model';
 export default class MinisterIssuePasture extends Model {
   static get fields() {
     // primary key *must* be first!
-    return ['id', 'minister_issue_id', 'pasture_id']
+    return ['id', 'minister_issue_id', 'pasture_id', 'canonical_id']
       .map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/monitoringarea.js
+++ b/src/libs/db2/model/monitoringarea.js
@@ -24,7 +24,7 @@ export default class MonitoringArea extends Model {
     // primary key *must* be first!
     return [
       'id', 'rangeland_health_id', 'plant_community_id', 'name', 'other_purpose',
-      'location', 'transect_azimuth', 'latitude', 'longitude',
+      'location', 'transect_azimuth', 'latitude', 'longitude', 'canonical_id',
     ].map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/monitoringareapurpose.js
+++ b/src/libs/db2/model/monitoringareapurpose.js
@@ -22,7 +22,7 @@ export default class MonitoringAreaPurpose extends Model {
   static get fields() {
     // primary key *must* be first!
     return [
-      'id', 'purpose_type_id', 'monitoring_area_id',
+      'id', 'purpose_type_id', 'monitoring_area_id', 'canonical_id',
     ].map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/pasture.js
+++ b/src/libs/db2/model/pasture.js
@@ -39,7 +39,7 @@ export default class Pasture extends Model {
   static get fields() {
     // primary key *must* be first!
     return ['id', 'name', 'allowable_aum', 'grace_days', 'pld_percent',
-      'notes', 'plan_id']
+      'notes', 'plan_id', 'canonical_id']
       .map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -82,7 +82,8 @@ export default class Plan extends Model {
     try {
       const { rows: [currentVersion] } = await db.raw(`
         SELECT plan.*
-        FROM plan_version, plan
+        FROM plan_version
+        INNER JOIN plan ON plan_version.plan_id = plan.id
         WHERE plan_version.canonical_id = ? AND version = -1;
         `, [canonicalId]);
       return currentVersion;

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -358,6 +358,13 @@ export default class Plan extends Model {
 
       const newConsiderations = await Promise.all(managementConsiderationPromises);
 
+      const { id, ...invasivePlantChecklist } = plan.invasivePlantChecklist;
+
+      const newInvasivePlantChecklist = await InvasivePlantChecklist.create(db, {
+        ...invasivePlantChecklist,
+        plan_id: newPlan.id,
+      });
+
       db.raw('COMMIT');
 
       return {
@@ -367,6 +374,7 @@ export default class Plan extends Model {
         ministerIssues: newMinisterIssues,
         managementConsiderations: newConsiderations,
         grazingSchedules: newGrazingSchedules,
+        invasivePlantChecklist: newInvasivePlantChecklist,
       };
     } catch (e) {
       db.raw('ROLLBACK');

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -62,12 +62,25 @@ export default class Plan extends Model {
       'id', 'range_name', 'plan_start_date', 'plan_end_date',
       'notes', 'alt_business_name', 'agreement_id', 'status_id',
       'uploaded', 'amendment_type_id', 'created_at', 'updated_at',
-      'effective_at', 'submitted_at', 'creator_id',
+      'effective_at', 'submitted_at', 'creator_id', 'canonical_id',
     ].map(f => `${Plan.table}.${f}`);
   }
 
   static get table() {
     return 'plan';
+  }
+
+  static async findCurrentVersion(db, canonicalId) {
+    try {
+      const { rows: [currentVersion] } = await db.raw(`
+        SELECT plan.*
+        FROM plan_version, plan
+        WHERE plan_version.canonical_id = ? AND version = -1;
+        `, [canonicalId]);
+      return currentVersion;
+    } catch (e) {
+      return null;
+    }
   }
 
   static async findWithStatusExtension(

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -323,7 +323,7 @@ export default class Plan extends Model {
 
           const ministerPasturePromises = issue.pastures.map(
             async (pastureId) => {
-              const pasture = newPastures.find(p => p.original.id === pastureId);
+              const pasture = newPastures.find(p => p.original.canonicalId === pastureId);
               const newPasture = await MinisterIssuePasture.create(db, {
                 pasture_id: pasture.id,
                 minister_issue_id: newIssue.id,

--- a/src/libs/db2/model/plantcommunity.js
+++ b/src/libs/db2/model/plantcommunity.js
@@ -33,7 +33,7 @@ export default class PlantCommunity extends Model {
       'id', 'community_type_id', 'elevation_id', 'pasture_id',
       'purpose_of_action', 'name', 'aspect', 'url', 'notes',
       'range_readiness_day', 'range_readiness_month', 'range_readiness_note',
-      'approved', 'shrub_use',
+      'approved', 'shrub_use', 'canonical_id',
     ].map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/plantcommunityaction.js
+++ b/src/libs/db2/model/plantcommunityaction.js
@@ -25,6 +25,7 @@ export default class PlantCommunityAction extends Model {
       'id', 'plant_community_id', 'action_type_id',
       'name', 'details', 'no_graze_start_day',
       'no_graze_start_month', 'no_graze_end_day', 'no_graze_end_month',
+      'canonical_id',
     ].map(field => `${this.table}.${field}`);
   }
 

--- a/src/libs/db2/model/planversion.js
+++ b/src/libs/db2/model/planversion.js
@@ -1,0 +1,28 @@
+import Model from './model';
+import User from './user';
+
+export default class PlanVersion extends Model {
+  constructor(data, db = undefined) {
+    const obj = {};
+    Object.keys(data).forEach((key) => {
+      if (PlanVersion.fields.indexOf(`${PlanVersion.table}.${key}`) > -1) {
+        obj[key] = data[key];
+      }
+    });
+
+    super(obj, db);
+
+    this.creator = new User(User.extract(data));
+  }
+
+  static get fields() {
+    // primary key *must* be first!
+    return [
+      'canonical_id', 'version', 'plan_id',
+    ].map(f => `${PlanVersion.table}.${f}`);
+  }
+
+  static get table() {
+    return 'plan_version';
+  }
+}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -72,3 +72,24 @@ export const checkRequiredFields = (fields = [], prop, req) => {
   }
   return undefined;
 };
+
+export const deepMapKeys = (originalObject, callback) => {
+  if (typeof originalObject !== 'object' || originalObject === null || originalObject instanceof Date) {
+    return originalObject;
+  }
+
+  return Object.keys(originalObject || {}).reduce((newObject, key) => {
+    const newKey = callback(key);
+    const originalValue = originalObject[key];
+    let newValue = originalValue;
+    if (Array.isArray(originalValue)) {
+      newValue = originalValue.map(item => deepMapKeys(item, callback));
+    } else if (typeof originalValue === 'object') {
+      newValue = deepMapKeys(originalValue, callback);
+    }
+    return {
+      ...newObject,
+      [newKey]: newValue,
+    };
+  }, {});
+};

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -1,5 +1,5 @@
 import { errorWithCode, logger } from '@bcgov/nodejs-common-utils';
-import { checkRequiredFields } from '../../libs/utils';
+import { checkRequiredFields, deepMapKeys } from '../../libs/utils';
 import DataManager from '../../libs/db2';
 import config from '../../config';
 import { PlanRouteHelper } from '../helpers';
@@ -58,7 +58,9 @@ export default class PlanController {
 
       const { canonicalId: planCanonicalId, ...planData } = plan;
 
-      return res.status(200).json({ ...planData, id: planCanonicalId }).end();
+      const formattedPlanData = deepMapKeys(planData, key => (key === 'canonicalId' ? 'id' : key));
+
+      return res.status(200).json({ ...formattedPlanData, id: planCanonicalId }).end();
     } catch (error) {
       logger.error(`Unable to fetch plan, error: ${error.message}`);
       throw errorWithCode(`There was a problem fetching the record. Error: ${error.message}`, error.code || 500);

--- a/src/router/controllers_v1/PlanInvasivePlantController.js
+++ b/src/router/controllers_v1/PlanInvasivePlantController.js
@@ -47,8 +47,8 @@ export default class PlanInvasivePlantController {
         throw errorWithCode(`Invasive plant checklist already exist with the plan id ${planId}`);
       }
 
-      const checklist = await InvasivePlantChecklist.create(db, { ...body, plan_id: planId });
-      return res.status(200).json(checklist).end();
+      const { canonicalId: checklistCanonicalId, ...checklist } = await InvasivePlantChecklist.create(db, { ...body, plan_id: planId });
+      return res.status(200).json({ ...checklist, id: checklistCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanInvasivePlantController: store: fail with error: ${error.message}`);
       throw error;
@@ -84,13 +84,13 @@ export default class PlanInvasivePlantController {
       const agreementId = await Plan.agreementForPlanId(db, planId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const updatedChecklist = await InvasivePlantChecklist.update(
+      const { canonicalId: checklistCanonicalId, ...updatedChecklist } = await InvasivePlantChecklist.update(
         db,
         { canonical_id: checklistId, plan_id: planId },
         body,
       );
 
-      return res.status(200).json(updatedChecklist).end();
+      return res.status(200).json({ ...updatedChecklist, id: checklistCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanInvasivePlantController: update: fail with error: ${error.message}`);
       throw error;

--- a/src/router/controllers_v1/PlanManagementConsiderationController.js
+++ b/src/router/controllers_v1/PlanManagementConsiderationController.js
@@ -42,9 +42,9 @@ export default class PlanManagementConsiderationController {
       const agreementId = await Plan.agreementForPlanId(db, planId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const consideration = await ManagementConsideration.create(db, { ...body, plan_id: planId });
+      const { canonicalId: considerationCanonicalId, ...consideration } = await ManagementConsideration.create(db, { ...body, plan_id: planId });
 
-      return res.status(200).json(consideration).end();
+      return res.status(200).json({ ...consideration, id: considerationCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanManagementConsiderationController: store: fail with error: ${error.message}`);
       throw error;
@@ -80,13 +80,13 @@ export default class PlanManagementConsiderationController {
       const agreementId = await Plan.agreementForPlanId(db, planId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const updated = await ManagementConsideration.update(
+      const { canonicalId: considerationCanonicalId, ...updated } = await ManagementConsideration.update(
         db,
         { canonical_id: considerationId, plan_id: planId },
         { ...body, plan_id: planId },
       );
 
-      return res.status(200).json(updated).end();
+      return res.status(200).json({ ...updated, id: considerationCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanManagementConsiderationController: update: fail with error: ${error.message}`);
       throw error;

--- a/src/router/controllers_v1/PlanMinisterIssueActionController.js
+++ b/src/router/controllers_v1/PlanMinisterIssueActionController.js
@@ -87,11 +87,11 @@ export default class PlanMinisterIssueActionController {
         data.no_graze_end_month = noGrazeEndMonth;
       }
 
-      const action = await MinisterIssueAction.create(
+      const { canonicalId: actionCanonicalId, ...action } = await MinisterIssueAction.create(
         db,
         data,
       );
-      return res.status(200).json(action).end();
+      return res.status(200).json({ ...action, id: actionCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanMinisterIssueActionController: store: fail with error: ${error.message}`);
       throw error;
@@ -164,13 +164,13 @@ export default class PlanMinisterIssueActionController {
 
       const issue = await MinisterIssue.findOne(db, { canonical_id: issueId, plan_id: planId });
 
-      const updatedAction = await MinisterIssueAction.update(
+      const { canonicalId: actionCanonicalId, ...updatedAction } = await MinisterIssueAction.update(
         db,
         { canonical_id: actionId, issue_id: issue.id },
         data,
       );
 
-      return res.status(200).json(updatedAction).end();
+      return res.status(200).json({ ...updatedAction, id: actionCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanMinisterIssueActionController: update: fail with error: ${error.message}`);
       throw error;

--- a/src/router/controllers_v1/PlanMinisterIssueActionController.js
+++ b/src/router/controllers_v1/PlanMinisterIssueActionController.js
@@ -1,9 +1,10 @@
-import { logger } from '@bcgov/nodejs-common-utils';
+import { errorWithCode, logger } from '@bcgov/nodejs-common-utils';
 import { checkRequiredFields } from '../../libs/utils';
 import { MINISTER_ISSUE_ACTION_TYPE } from '../../constants';
 import DataManager from '../../libs/db2';
 import config from '../../config';
 import { PlanRouteHelper } from '../helpers';
+import MinisterIssue from '../../libs/db2/model/ministerissue';
 
 const dm = new DataManager(config);
 const {
@@ -22,7 +23,7 @@ export default class PlanMinisterIssueActionController {
    */
   static async store(req, res) {
     const { body, params, user } = req;
-    const { planId, issueId } = params;
+    const { planId: canonicalId, issueId } = params;
     const {
       actionTypeId,
       detail,
@@ -41,14 +42,31 @@ export default class PlanMinisterIssueActionController {
       ['actionTypeId'], 'body', req,
     );
 
+    if (!canonicalId) {
+      throw errorWithCode('planId must be provided in path', 400);
+    }
+
+    const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+
+    if (!currentPlan) {
+      throw errorWithCode('Plan doesn\'t exist', 404);
+    }
+
+    const planId = currentPlan.id;
+
     try {
       const agreementId = await Plan.agreementForPlanId(db, planId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
+      const issue = await MinisterIssue.findOne(db, { canonical_id: issueId, plan_id: planId });
+      if (!issue) {
+        throw errorWithCode("Minister issue doesn't exist", 500);
+      }
+
       const data = {
         detail,
         action_type_id: actionTypeId,
-        issue_id: issueId,
+        issue_id: issue.id,
         other: null,
         no_graze_start_day: null,
         no_graze_start_month: null,
@@ -87,7 +105,7 @@ export default class PlanMinisterIssueActionController {
    */
   static async update(req, res) {
     const { body, params, user } = req;
-    const { planId, actionId } = params;
+    const { planId: canonicalId, issueId, actionId } = params;
     const {
       actionTypeId,
       detail,
@@ -105,6 +123,18 @@ export default class PlanMinisterIssueActionController {
     checkRequiredFields(
       ['actionTypeId'], 'body', req,
     );
+
+    if (!canonicalId) {
+      throw errorWithCode('planId must be provided in path', 400);
+    }
+
+    const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+
+    if (!currentPlan) {
+      throw errorWithCode('Plan doesn\'t exist', 404);
+    }
+
+    const planId = currentPlan.id;
 
     try {
       const agreementId = await Plan.agreementForPlanId(db, planId);
@@ -132,9 +162,11 @@ export default class PlanMinisterIssueActionController {
         data.no_graze_end_month = noGrazeEndMonth;
       }
 
+      const issue = await MinisterIssue.findOne(db, { canonical_id: issueId, plan_id: planId });
+
       const updatedAction = await MinisterIssueAction.update(
         db,
-        { id: actionId },
+        { canonical_id: actionId, issue_id: issue.id },
         data,
       );
 
@@ -152,17 +184,34 @@ export default class PlanMinisterIssueActionController {
    */
   static async destroy(req, res) {
     const { params, user } = req;
-    const { planId, actionId } = params;
+    const { planId: canonicalId, issueId, actionId } = params;
 
     checkRequiredFields(
       ['planId', 'issueId', 'actionId'], 'params', req,
     );
 
+    if (!canonicalId) {
+      throw errorWithCode('planId must be provided in path', 400);
+    }
+
+    const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+
+    if (!currentPlan) {
+      throw errorWithCode('Plan doesn\'t exist', 404);
+    }
+
+    const planId = currentPlan.id;
+
     try {
       const agreementId = await Plan.agreementForPlanId(db, planId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const results = await MinisterIssueAction.removeById(db, actionId);
+      const issue = await MinisterIssue.findOne(db, { canonical_id: issueId, plan_id: planId });
+
+      const results = await MinisterIssueAction.remove(
+        db,
+        { canonical_id: actionId, issue_id: issue.id },
+      );
 
       return res.status(204).json({
         success: (results.length > 0),

--- a/src/router/controllers_v1/PlanMinisterIssueController.js
+++ b/src/router/controllers_v1/PlanMinisterIssueController.js
@@ -40,7 +40,7 @@ export default class PlanMinisterIssueController {
       // associated to the issue belong to the current plan.
       const plan = await Plan.findById(db, planId);
       await plan.fetchPastures();
-      const okPastureIds = plan.pastures.map(pasture => pasture.id);
+      const okPastureIds = plan.pastures.map(pasture => pasture.canonicalId);
       const status = pastures.every(i => okPastureIds.includes(i));
       if (!status) {
         throw errorWithCode('Some pastures do not belong to the current user ', 400);

--- a/src/router/controllers_v1/PlanMinisterIssueController.js
+++ b/src/router/controllers_v1/PlanMinisterIssueController.js
@@ -115,12 +115,12 @@ export default class PlanMinisterIssueController {
         MinisterIssuePasture.create(db, { pasture_id: id, minister_issue_id: issue.id }));
       if (promises) await Promise.all(promises);
 
-      const createdIssue = {
+      const { canonicalId: issueCanonicalId, ...createdIssue } = {
         ...issue,
         pastures,
       };
 
-      return res.status(200).json(createdIssue).end();
+      return res.status(200).json({ ...createdIssue, id: issueCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanMinisterIssueController: store: fail with error: ${error.message}`);
       throw error;
@@ -176,12 +176,12 @@ export default class PlanMinisterIssueController {
       await Promise.all(pastures.map(id =>
         MinisterIssuePasture.create(db, { pasture_id: id, minister_issue_id: issue.id })));
 
-      const updatedIssue = {
+      const { canonicalId: issueCanonicalId, ...updatedIssue } = {
         ...issue,
         pastures,
       };
 
-      return res.status(200).json(updatedIssue).end();
+      return res.status(200).json({ ...updatedIssue, id: issueCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanMinisterIssueController: update: fail with error: ${error.message}`);
       throw error;

--- a/src/router/controllers_v1/PlanPastureController.js
+++ b/src/router/controllers_v1/PlanPastureController.js
@@ -326,9 +326,14 @@ export default class PlanPastureController {
         db, { monitoring_area_id: monitoringArea.id },
       );
 
+      const purposes = monitoringArea.purposes.map(({ canonicalId: purposeCanonicalId, ...purpose }) => ({
+        ...purpose,
+        id: purposeCanonicalId,
+      }));
+
       const { canonicalId: areaCanonicalId, ...newMonitoringArea } = monitoringArea;
 
-      return res.status(200).json({ ...newMonitoringArea, id: areaCanonicalId }).end();
+      return res.status(200).json({ ...newMonitoringArea, id: areaCanonicalId, purposes }).end();
     } catch (error) {
       logger.error(`PlanPastureController: storeMonitoringArea: fail with error: ${error.message}`);
       throw error;

--- a/src/router/controllers_v1/PlanPastureController.js
+++ b/src/router/controllers_v1/PlanPastureController.js
@@ -48,9 +48,9 @@ export default class PlanPastureController {
       delete body.planId;
       delete body.plan_id;
 
-      const pasture = await Pasture.create(db, { ...body, plan_id: planId });
+      const { canonicalId: pastureCanonicalId, ...pasture } = await Pasture.create(db, { ...body, plan_id: planId });
 
-      return res.status(200).json(pasture).end();
+      return res.status(200).json({ ...pasture, id: pastureCanonicalId }).end();
     } catch (err) {
       logger.error(`PlanPastureController:store: fail with error: ${err.message}`);
       throw err;
@@ -87,13 +87,13 @@ export default class PlanPastureController {
       delete body.planId;
       delete body.plan_id;
 
-      const updatedPasture = await Pasture.update(
+      const { canonicalId: pastureCanonicalId, ...updatedPasture } = await Pasture.update(
         db,
         { canonical_id: pastureId, plan_id: planId },
         { ...body, plan_id: planId },
       );
 
-      return res.status(200).json(updatedPasture).end();
+      return res.status(200).json({ ...updatedPasture, id: pastureCanonicalId }).end();
     } catch (err) {
       logger.error(`PlanPastureController: update: fail with error: ${err.message}`);
       throw err;
@@ -129,8 +129,8 @@ export default class PlanPastureController {
       if (!PURPOSE_OF_ACTION.includes(purposeOfAction)) {
         throw errorWithCode(`Unacceptable purpose of action with "${purposeOfAction}"`);
       }
-      const plantCommunity = await PlantCommunity.create(db, { ...body, pastureId });
-      return res.status(200).json(plantCommunity).end();
+      const { canonicalId: communityCanonicalId, ...plantCommunity } = await PlantCommunity.create(db, { ...body, pastureId });
+      return res.status(200).json({ ...plantCommunity, id: communityCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanPastureController: storePlatCommunity: fail with error: ${error.message}`);
       throw error;
@@ -177,13 +177,13 @@ export default class PlanPastureController {
       throw errorWithCode("Plant community doesn't exist", 404);
     }
 
-    const updatedPlantCommunity = await PlantCommunity.update(
+    const { canonicalId: communityCanonicalId, ...updatedPlantCommunity } = await PlantCommunity.update(
       db,
       { id: plantCommunity.id },
       { ...body, plan_id: planId, pasture_id: pasture.id, canonical_id: communityId },
     );
 
-    return res.json(updatedPlantCommunity).end();
+    return res.json({ ...updatedPlantCommunity, id: communityCanonicalId }).end();
   }
 
 
@@ -216,14 +216,14 @@ export default class PlanPastureController {
       if (!plantCommunity) {
         throw errorWithCode(`No plant community found with id: ${communityId}`);
       }
-      const plantCommunityAction = await PlantCommunityAction.create(
+      const { canonicalId: actionCanonicalId, ...plantCommunityAction } = await PlantCommunityAction.create(
         db,
         {
           ...body,
           plantCommunityId: communityId,
         },
       );
-      return res.status(200).json(plantCommunityAction).end();
+      return res.status(200).json({ ...plantCommunityAction, id: actionCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanPastureController: storePlantCommunityAction: fail with error: ${error.message}`);
       throw error;
@@ -265,14 +265,14 @@ export default class PlanPastureController {
         throw errorWithCode(`No plant community found with id: ${communityId}`);
       }
 
-      const indicatorPlant = await IndicatorPlant.create(
+      const { canonicalId: plantCanonicalId, ...indicatorPlant } = await IndicatorPlant.create(
         db,
         {
           ...body,
           plantCommunityId: communityId,
         },
       );
-      return res.status(200).json(indicatorPlant).end();
+      return res.status(200).json({ ...indicatorPlant, id: plantCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanPastureController: storeIndicatorPlant: fail with error: ${error.message}`);
       throw error;
@@ -326,7 +326,9 @@ export default class PlanPastureController {
         db, { monitoring_area_id: monitoringArea.id },
       );
 
-      return res.status(200).json(monitoringArea).end();
+      const { canonicalId: areaCanonicalId, ...newMonitoringArea } = monitoringArea;
+
+      return res.status(200).json({ ...newMonitoringArea, id: areaCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanPastureController: storeMonitoringArea: fail with error: ${error.message}`);
       throw error;

--- a/src/router/controllers_v1/PlanScheduleController.js
+++ b/src/router/controllers_v1/PlanScheduleController.js
@@ -72,7 +72,10 @@ export default class PlanScheduleController {
       await Promise.all(promises);
       await schedule.fetchGrazingSchedulesEntries();
 
-      return res.status(200).json(schedule).end();
+      const { canonicalId: scheduleCanonicalId, ...newSchedule } = schedule;
+      const entries = schedule.grazingScheduleEntries.map(({ canonicalId: entryCanonicalId, ...entry }) => ({ ...entry, id: entryCanonicalId }));
+
+      return res.status(200).json({ ...newSchedule, id: scheduleCanonicalId, grazingScheduleEntries: entries }).end();
     } catch (error) {
       logger.error(`PlanScheduleController: store: fail with error: ${error.message}`);
       throw error;
@@ -151,7 +154,10 @@ export default class PlanScheduleController {
       await Promise.all(promises);
       await schedule.fetchGrazingSchedulesEntries();
 
-      return res.status(200).json(schedule).end();
+      const { canonicalId: scheduleCanonicalId, ...updatedSchedule } = schedule;
+      const entries = schedule.grazingScheduleEntries.map(({ canonicalId: entryCanonicalId, ...entry }) => ({ ...entry, id: entryCanonicalId }));
+
+      return res.status(200).json({ ...updatedSchedule, id: scheduleCanonicalId, grazingScheduleEntries: entries }).end();
     } catch (error) {
       logger.error(`PlanScheduleController: update: fail with error: ${error.message}`);
       throw error;
@@ -220,12 +226,12 @@ export default class PlanScheduleController {
         throw errorWithCode('No such schedule exists', 400);
       }
 
-      const entry = await GrazingScheduleEntry.create(db, {
+      const { canonicalId: entryCanonicalId, ...entry } = await GrazingScheduleEntry.create(db, {
         ...body,
         ...{ grazing_schedule_id: scheduleId },
       });
 
-      return res.status(200).json(entry).end();
+      return res.status(200).json({ ...entry, id: entryCanonicalId }).end();
     } catch (error) {
       logger.error(`PlanScheduleController: storeScheduleEntry: fail with error: ${error.message}`);
       throw error;

--- a/src/router/controllers_v1/PlanStatusController.js
+++ b/src/router/controllers_v1/PlanStatusController.js
@@ -69,7 +69,7 @@ export default class PlanStatusController {
   static async update(req, res) {
     const { params, body, user } = req;
     const { statusId, note } = body;
-    const { planId } = params;
+    const { planId: canonicalId } = params;
 
     checkRequiredFields(
       ['planId'], 'params', req,
@@ -81,6 +81,18 @@ export default class PlanStatusController {
     if (!isNumeric(statusId)) {
       throw errorWithCode('statusId must be numeric', 400);
     }
+
+    if (!canonicalId) {
+      throw errorWithCode('planId must be provided in path', 400);
+    }
+
+    const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+
+    if (!currentPlan) {
+      throw errorWithCode('Plan doesn\'t exist', 404);
+    }
+
+    const planId = currentPlan.id;
 
     try {
       const agreementId = await Plan.agreementForPlanId(db, planId);
@@ -121,11 +133,23 @@ export default class PlanStatusController {
       body,
       user,
     } = req;
-    const { planId, confirmationId } = params;
+    const { planId: canonicalId, confirmationId } = params;
 
     checkRequiredFields(
       ['planId', 'confirmationId'], 'params', req,
     );
+
+    if (!canonicalId) {
+      throw errorWithCode('planId must be provided in path', 400);
+    }
+
+    const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+
+    if (!currentPlan) {
+      throw errorWithCode('Plan doesn\'t exist', 404);
+    }
+
+    const planId = currentPlan.id;
 
     try {
       const agreementId = await Plan.agreementForPlanId(db, planId);
@@ -167,7 +191,7 @@ export default class PlanStatusController {
    */
   static async storeStatusHistory(req, res) {
     const { params, body, user } = req;
-    const { planId } = params;
+    const { planId: canonicalId } = params;
 
     checkRequiredFields(
       ['planId'], 'params', req,
@@ -175,6 +199,18 @@ export default class PlanStatusController {
     checkRequiredFields(
       ['fromPlanStatusId', 'toPlanStatusId', 'note'], 'body', req,
     );
+
+    if (!canonicalId) {
+      throw errorWithCode('planId must be provided in path', 400);
+    }
+
+    const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+
+    if (!currentPlan) {
+      throw errorWithCode('Plan doesn\'t exist', 404);
+    }
+
+    const planId = currentPlan.id;
 
     try {
       const agreementId = await Plan.agreementForPlanId(db, planId);

--- a/src/router/controllers_v1/PlanVersionController.js
+++ b/src/router/controllers_v1/PlanVersionController.js
@@ -14,11 +14,11 @@ const {
 
 export default class PlanVersionController {
   static async store(req, res) {
-    const { body, user } = req;
+    const { user, params } = req;
     // The "plan id" sent in a request is actually the canonical ID of a resource
-    const { planId: canonicalId } = body;
+    const { planId: canonicalId } = params;
 
-    checkRequiredFields(['planId'], 'body', req);
+    checkRequiredFields(['planId'], 'params', req);
 
 
     try {

--- a/src/router/controllers_v1/PlanVersionController.js
+++ b/src/router/controllers_v1/PlanVersionController.js
@@ -1,0 +1,71 @@
+import { errorWithCode, logger } from '@bcgov/nodejs-common-utils';
+import { checkRequiredFields } from '../../libs/utils';
+import DataManager from '../../libs/db2';
+import config from '../../config';
+import { PlanRouteHelper } from '../helpers';
+
+const dm = new DataManager(config);
+const {
+  db,
+  Plan,
+  Agreement,
+  PlanVersion,
+} = dm;
+
+export default class PlanVersionController {
+  static async store(req, res) {
+    const { body, user } = req;
+    // The "plan id" sent in a request is actually the canonical ID of a resource
+    const { planId: canonicalId } = body;
+
+    checkRequiredFields(['planId'], 'body', req);
+
+
+    // Wrap all queries in a transaction
+    try {
+      await db.raw('BEGIN');
+
+      const { rows: versionRows } = await db.raw(`
+      SELECT plan.*
+      FROM plan_version, plan
+      WHERE plan_version.canonical_id = ? AND version = -1;
+      `, [canonicalId]);
+
+      if (versionRows.length !== 1) {
+        throw errorWithCode('Could not find plan', 404);
+      }
+
+
+      const { id: currentPlanId, ...currentPlan } = versionRows[0];
+
+      const agreementId = await Plan.agreementForPlanId(db, currentPlanId);
+      await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
+
+      // TODO: Replace this with duplication logic for ALL tables
+      const newPlan = await Plan.create(db, {
+        ...currentPlan,
+      });
+
+      // Create new plan version record to point to original plan. This will be
+      // the point-in-time snapshot of the plan. The original plan should no
+      // longer be mutated
+      await PlanVersion.create(db, {
+        canonicalId,
+        planId: currentPlanId,
+      });
+
+      // Update current version to point to new plan
+      await PlanVersion.update(db, { canonical_id: canonicalId, version: -1 }, {
+        planId: newPlan.id,
+      });
+
+      await db.raw('COMMIT');
+    } catch (error) {
+      logger.log(error);
+      await db.raw('ROLLBACK');
+      throw error;
+    }
+
+    return res.status(200).json({ message: 'Created new version' }).end();
+  }
+}

--- a/src/router/controllers_v1/PlanVersionController.js
+++ b/src/router/controllers_v1/PlanVersionController.js
@@ -22,17 +22,12 @@ export default class PlanVersionController {
 
 
     try {
-      const { rows: versionRows } = await db.raw(`
-      SELECT plan.*
-      FROM plan_version, plan
-      WHERE plan_version.canonical_id = ? AND version = -1;
-      `, [canonicalId]);
-
-      if (versionRows.length !== 1) {
+      const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+      if (!currentPlan) {
         throw errorWithCode('Could not find plan', 404);
       }
 
-      const { id: currentPlanId } = versionRows[0];
+      const { id: currentPlanId } = currentPlan;
 
       const agreementId = await Plan.agreementForPlanId(db, currentPlanId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);

--- a/src/router/routes_v1/plan.js
+++ b/src/router/routes_v1/plan.js
@@ -77,6 +77,9 @@ router.put('/:planId?/pasture/:pastureId?', asyncMiddleware(PlanPastureControlle
 // create a plant community
 router.post('/:planId?/pasture/:pastureId?/plant-community', asyncMiddleware(PlanPastureController.storePlatCommunity));
 
+// Update an existing plant community
+router.put('/:planId?/pasture/:pastureId?/plant-community/:communityId', asyncMiddleware(PlanPastureController.updatePlantCommunity));
+
 // create a plant community action
 router.post('/:planId?/pasture/:pastureId?/plant-community/:communityId/action', asyncMiddleware(PlanPastureController.storePlantCommunityAction));
 

--- a/src/router/routes_v1/plan.js
+++ b/src/router/routes_v1/plan.js
@@ -29,6 +29,7 @@ import { Router } from 'express';
  * Controller for individual routes related to plan.
  */
 import PlanController from '../controllers_v1/PlanController';
+import PlanVersionController from '../controllers_v1/PlanVersionController';
 import PlanStatusController from '../controllers_v1/PlanStatusController';
 import PlanPastureController from '../controllers_v1/PlanPastureController';
 import PlanScheduleController from '../controllers_v1/PlanScheduleController';
@@ -56,6 +57,12 @@ router.put('/:planId?/confirmation/:confirmationId?', asyncMiddleware(PlanStatus
 
 // create a plan status history
 router.post('/:planId?/status-record', asyncMiddleware(PlanStatusController.storeStatusHistory));
+
+//
+// Versions
+//
+
+router.post('/:planId?/version', asyncMiddleware(PlanVersionController.store))
 
 //
 // Pasture


### PR DESCRIPTION
Versions are now tracked in a new `plan_version` table, which relates versions to plan IDs. The entries with a version of -1 point to the current version of the plan. All CRUD operations will be done against the current version of a plan. Whenever a new version of a plan is created, the current plan and all related rows are duplicated. For the client, this duplication is handled transparently, as all API operations use a `canonical_id` column on the tables instead of the actual `id`. The canonical ID will stay constant between duplications, and the actual row ID is only used internally. 
