### PR TITLE
Add endpoints to get plan versions

### DIFF
--- a/__tests__/api_v1/plan/version.spec.js
+++ b/__tests__/api_v1/plan/version.spec.js
@@ -254,4 +254,23 @@ describe('Test Plan routes', () => {
       .get('/api/v1/plan/2/version')
       .expect(404);
   });
+
+  test('Getting a specific version of a plan', async () => {
+    const [version] = await dm.db('plan_version').where('canonical_id', 1).where('version', 1);
+    const [plan] = await dm.db('plan').where('id', version.plan_id);
+
+    await request(app)
+      .get(`${baseUrl}/1`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.version).toEqual(version.version);
+        expect(res.body.id).toEqual(plan.id);
+      });
+  });
+
+  test('Getting a nonexistant version of a plan throws a 404 error', async () => {
+    await request(app)
+      .get(`${baseUrl}/10`)
+      .expect(404);
+  });
 });

--- a/__tests__/api_v1/plan/version.spec.js
+++ b/__tests__/api_v1/plan/version.spec.js
@@ -256,15 +256,15 @@ describe('Test Plan routes', () => {
   });
 
   test('Getting a specific version of a plan', async () => {
-    const [version] = await dm.db('plan_version').where('canonical_id', 1).where('version', 1);
+    const [version] = await dm.db('plan_version').where('canonical_id', 1).where('version', -1);
     const [plan] = await dm.db('plan').where('id', version.plan_id);
 
     await request(app)
-      .get(`${baseUrl}/1`)
+      .get(`${baseUrl}/-1`)
       .expect(200)
       .expect((res) => {
         expect(res.body.version).toEqual(version.version);
-        expect(res.body.id).toEqual(plan.id);
+        expect(res.body.id).toEqual(plan.canonical_id);
       });
   });
 

--- a/src/libs/db2/migrations/20191106113028_add_version_created_at_column.js
+++ b/src/libs/db2/migrations/20191106113028_add_version_created_at_column.js
@@ -1,0 +1,24 @@
+const table = 'plan_version';
+
+exports.up = async (knex) => {
+  await knex.schema.table(table, async (t) => {
+    t.dateTime('created_at').notNull().defaultTo(knex.raw('CURRENT_TIMESTAMP(3)'));
+    t.dateTime('updated_at').notNull().defaultTo(knex.raw('CURRENT_TIMESTAMP(3)'));
+
+    const query = `
+    CREATE TRIGGER update_${table}_changetimestamp BEFORE UPDATE
+    ON ${table} FOR EACH ROW EXECUTE PROCEDURE 
+    update_changetimestamp_column();`;
+
+    await knex.schema.raw(query);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table(table, async (t) => {
+    t.dropTable('created_at');
+    t.dropTable('updated_at');
+
+    await knex.schema.raw(`REMOVE TRIGGER update_${table}_changetimestamp ON ${table}`);
+  });
+};

--- a/src/libs/db2/model/planversion.js
+++ b/src/libs/db2/model/planversion.js
@@ -18,7 +18,7 @@ export default class PlanVersion extends Model {
   static get fields() {
     // primary key *must* be first!
     return [
-      'canonical_id', 'version', 'plan_id',
+      'canonical_id', 'version', 'plan_id', 'created_at', 'updated_at',
     ].map(f => `${PlanVersion.table}.${f}`);
   }
 

--- a/src/router/controllers_v1/PlanVersionController.js
+++ b/src/router/controllers_v1/PlanVersionController.js
@@ -114,6 +114,7 @@ export default class PlanVersionController {
       const { planId, version: planVersion } = versionData;
 
       const plan = await Plan.findById(db, planId);
+      await plan.eagerloadAllOneToMany();
 
       const formattedPlanData = deepMapKeys(plan, key => (key === 'canonicalId' ? 'id' : key));
 

--- a/src/router/controllers_v1/PlanVersionController.js
+++ b/src/router/controllers_v1/PlanVersionController.js
@@ -1,5 +1,5 @@
 import { errorWithCode, logger } from '@bcgov/nodejs-common-utils';
-import { checkRequiredFields } from '../../libs/utils';
+import { checkRequiredFields, deepMapKeys } from '../../libs/utils';
 import DataManager from '../../libs/db2';
 import config from '../../config';
 import { PlanRouteHelper } from '../helpers';
@@ -78,6 +78,46 @@ export default class PlanVersionController {
       );
 
       return res.status(200).json({ versions }).end();
+    } catch (error) {
+      logger.error(error);
+      throw error;
+    }
+  }
+
+  static async show(req, res) {
+    const { user, params } = req;
+    // The "plan id" sent in a request is actually the canonical ID of a resource
+    const { planId: canonicalId, version } = params;
+
+    checkRequiredFields(['planId', 'version'], 'params', req);
+
+    try {
+      const currentPlan = await Plan.findCurrentVersion(db, canonicalId);
+      if (!currentPlan) {
+        throw errorWithCode('Could not find plan', 404);
+      }
+
+      const { id: currentPlanId } = currentPlan;
+
+      const agreementId = await Plan.agreementForPlanId(db, currentPlanId);
+      await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
+
+      const versionData = await PlanVersion.findOne(
+        db,
+        { canonical_id: canonicalId, version },
+      );
+
+      if (!versionData) {
+        throw errorWithCode('Could not find version for plan', 404);
+      }
+
+      const { planId, version: planVersion } = versionData;
+
+      const plan = await Plan.findById(db, planId);
+
+      const formattedPlanData = deepMapKeys(plan, key => (key === 'canonicalId' ? 'id' : key));
+
+      return res.status(200).json({ ...formattedPlanData, version: planVersion }).end();
     } catch (error) {
       logger.error(error);
       throw error;

--- a/src/router/routes_v1/plan.js
+++ b/src/router/routes_v1/plan.js
@@ -68,6 +68,9 @@ router.post('/:planId?/version', asyncMiddleware(PlanVersionController.store));
 // Get all versions for a plan
 router.get('/:planId?/version', asyncMiddleware(PlanVersionController.showAll));
 
+// Get a specific version for a plan
+router.get('/:planId?/version/:version?', asyncMiddleware(PlanVersionController.show));
+
 //
 // Pasture
 //

--- a/src/router/routes_v1/plan.js
+++ b/src/router/routes_v1/plan.js
@@ -62,7 +62,11 @@ router.post('/:planId?/status-record', asyncMiddleware(PlanStatusController.stor
 // Versions
 //
 
-router.post('/:planId?/version', asyncMiddleware(PlanVersionController.store))
+// Create a new version
+router.post('/:planId?/version', asyncMiddleware(PlanVersionController.store));
+
+// Get all versions for a plan
+router.get('/:planId?/version', asyncMiddleware(PlanVersionController.showAll));
 
 //
 // Pasture


### PR DESCRIPTION
New endpoints:
* `GET /api/v1/plan/:planId/version`: Returns all `plan_version` records that are associated with the provided `planId`
* `GET /api/v1/plan/:planId/version/:version`: Returns the plan that matches the provided `version`