### PR TITLE
Fix minister issue action versioning

### DIFF
--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -311,7 +311,7 @@ export default class Plan extends Model {
             async ({ id: actionId, ...action }) => {
               const newAction = await MinisterIssueAction.create(db, {
                 ...action,
-                minister_issue_id: newIssue.id,
+                issue_id: newIssue.id,
               });
 
 


### PR DESCRIPTION
Was using a mistyped column name to reference duplicated issue actions to their respective minister issues.