### PR TITLE
Fix minister issue action sort order

### DIFF
--- a/src/libs/db2/model/grazingscheduleentry.js
+++ b/src/libs/db2/model/grazingscheduleentry.js
@@ -22,6 +22,7 @@
 
 import LivestockType from './livestocktype';
 import Model from './model';
+import Pasture from './pasture';
 
 export default class GrazingScheduleEntry extends Model {
   constructor(data, db = undefined) {
@@ -52,6 +53,7 @@ export default class GrazingScheduleEntry extends Model {
     const myFields = [
       ...GrazingScheduleEntry.fields,
       ...LivestockType.fields.map(f => `${f} AS ${f.replace('.', '_')}`),
+      ...Pasture.fields.map(f => `${f} AS ${f.replace('.', '_')}`),
     ];
 
     try {

--- a/src/libs/db2/model/ministerissueaction.js
+++ b/src/libs/db2/model/ministerissueaction.js
@@ -67,7 +67,7 @@ export default class MinisterIssueAction extends Model {
         .from(MinisterIssueAction.table)
         .join('ref_minister_issue_action_type', { 'minister_issue_action.action_type_id': 'ref_minister_issue_action_type.id' })
         .where(where)
-        .orderBy('minister_issue_action.created_at', 'desc');
+        .orderBy('minister_issue_action.created_at', 'asc');
 
       return results.map(row => new MinisterIssueAction(row, db));
     } catch (err) {


### PR DESCRIPTION
Changes the sort order to ascending, instead of descending, by `created_at` date.

Relates to https://github.com/bcgov/range-web/issues/492