### PR TITLE
Send correct snapshot from version endpoint

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -36,10 +36,10 @@ jobs:
 
         POSTGRESQL_PASSWORD: banana
         POSTGRESQL_USER: app_dv_myra
+
+        CI: true
       run: |
         npm ci
         make local-test-setup
         docker-compose up -d
         npm test -- --forceExit
-      env:
-        CI: true

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -14,21 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
-
-    env:
-      POSTGRESQL_DATABASE: myra
-      POSTGRESQL_DATABASE_TEST: myra_test
-      POSTGRESQL_HOST: db
-      POSTGRESQL_PORT: 5432
-
-      PROJECT: myra_range
-      ENVIRONMENT: development
-      API_PORT: 8080
-      BUILD_TARGET: base
-
-      POSTGRESQL_PASSWORD: banana
-      POSTGRESQL_USER: app_dv_myra
+        node-version: [10.x] 
 
     steps:
     - uses: actions/checkout@v1
@@ -37,19 +23,20 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
-      run: |
-        echo "POSTGRESQL_DATABASE: myra
+      env:
+        POSTGRESQL_DATABASE: myra
         POSTGRESQL_DATABASE_TEST: myra_test
         POSTGRESQL_HOST: db
         POSTGRESQL_PORT: 5432
-  
+
         PROJECT: myra_range
         ENVIRONMENT: development
         API_PORT: 8080
         BUILD_TARGET: base
-  
+
         POSTGRESQL_PASSWORD: banana
-        POSTGRESQL_USER: app_dv_myra" > .env
+        POSTGRESQL_USER: app_dv_myra
+      run: |
         npm ci
         make local-test-setup
         docker-compose up -d

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -39,6 +39,7 @@ jobs:
 
         CI: true
       run: |
+        echo "$(printenv)" > .env
         npm ci
         make local-test-setup
         docker-compose up -d

--- a/src/router/controllers_v1/PlanVersionController.js
+++ b/src/router/controllers_v1/PlanVersionController.js
@@ -83,27 +83,10 @@ export default class PlanVersionController {
         throw errorWithCode('Could not find version for plan', 404);
       }
 
-      const [plan] = await Plan.findWithStatusExtension(db, { 'plan.id': versionData.planId }, ['id', 'desc']);
-      if (!plan) {
-        throw errorWithCode('Could not find plan', 404);
-      }
-
-      const agreementId = await Plan.agreementForPlanId(db, plan.id);
+      const agreementId = await Plan.agreementForPlanId(db, versionData.planId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const [agreement] = await Agreement.findWithTypeZoneDistrictExemption(
-        db, { forest_file_id: agreementId },
-      );
-      await agreement.eagerloadAllOneToManyExceptPlan();
-      agreement.transformToV1();
-
-      await plan.eagerloadAllOneToMany();
-
-      return res.status(200).json({
-        ...plan,
-        agreement,
-        ...versionData,
-      }).end();
+      return res.json(versionData.snapshot).end();
     } catch (error) {
       logger.error(error);
       throw error;


### PR DESCRIPTION
The `GET /version/:version` endpoint was incorrectly serving the latest plan record for every `:version`. I've fixed it to return the proper snapshot instead.