### PR TITLE
Add back missing agreement section to version migration

### DIFF
--- a/src/libs/db2/migrations/20200303122440_remove-duplicates.js
+++ b/src/libs/db2/migrations/20200303122440_remove-duplicates.js
@@ -73,7 +73,10 @@ exports.up = async (knex) => {
           );
 
           const snapshot = await PlanSnapshot.create(knex, {
-            snapshot: JSON.stringify(plan),
+            snapshot: JSON.stringify({
+              ...plan,
+              agreement,
+            }),
             created_at: plan.created_at,
             version: lastVersion + (1 * i) + 1,
             plan_id: currentPlan.plan_id,


### PR DESCRIPTION
There was a bug in the version -> snapshot migration that was causing the `agreement` field to not be included in the snapshot.
