### PR TITLE
Add agreement to snapshot in original version migration

### DIFF
--- a/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
+++ b/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
@@ -54,7 +54,7 @@ exports.up = async (knex) => {
         await plan.eagerloadAllOneToMany();
 
         const snapshot = await PlanSnapshot.create(knex, {
-          snapshot: JSON.stringify(plan),
+          snapshot: JSON.stringify({ ...plan, agreement }),
           created_at: versionRecord.created_at,
           version: versionRecord.version,
           plan_id: currentPlanId,


### PR DESCRIPTION
Previous PR just addressed the duplicate removal migration, but the bug also appears in the original version -> snapshot migration. 