### PR TITLE
Update checkout action to v2

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: [10.x] 
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
`actions/checkout@v1` had some issues with race conditions, which is what was causing actions to periodically fail. This shouldn't happen in v2 anymore.