### PR TITLE
Capture user_id in plan_snapshot

### DIFF
--- a/src/libs/db2/migrations/20200414152434_trackversionuser.js
+++ b/src/libs/db2/migrations/20200414152434_trackversionuser.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  
+    knex.raw('ALTER TABLE plan_snapshot ADD COLUMN IF NOT EXISTS user_id INTEGER;')
+
+};
+
+exports.down = function(knex) {
+  
+    knex.raw('ALTER TABLE plan_snapshot DROP COLUMN IF EXISTS user_id;')
+
+};

--- a/src/libs/db2/migrations/20200414152434_trackversionuser.js
+++ b/src/libs/db2/migrations/20200414152434_trackversionuser.js
@@ -1,12 +1,12 @@
 
-exports.up = function(knex) {
+exports.up = async (knex) => {
   
-    knex.raw('ALTER TABLE plan_snapshot ADD COLUMN IF NOT EXISTS user_id INTEGER;')
+    await knex.raw("ALTER TABLE plan_snapshot ADD COLUMN IF NOT EXISTS user_id INTEGER;");
 
 };
 
-exports.down = function(knex) {
+exports.down = async (knex) => {
   
-    knex.raw('ALTER TABLE plan_snapshot DROP COLUMN IF EXISTS user_id;')
+    await knex.raw("ALTER TABLE plan_snapshot DROP COLUMN IF EXISTS user_id;");
 
 };

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -154,7 +154,7 @@ export default class Plan extends Model {
     return result.agreement_id;
   }
 
-  static async createSnapshot(db, planId) {
+  static async createSnapshot(db, planId,userId) {
     const [plan] = await Plan.findWithStatusExtension(db, { 'plan.id': planId }, ['id', 'desc']);
     if (!plan) {
       throw errorWithCode('Plan doesn\'t exist', 404);
@@ -185,6 +185,7 @@ export default class Plan extends Model {
       created_at: new Date(),
       version: lastVersion + 1,
       status_id: plan.statusId,
+      user_id: userId
     });
 
     return snapshotRecord;

--- a/src/libs/db2/model/plansnapshot.js
+++ b/src/libs/db2/model/plansnapshot.js
@@ -19,7 +19,7 @@ export default class PlanSnapshot extends Model {
   static get fields() {
     // primary key *must* be first!
     return [
-      'id', 'snapshot', 'plan_id', 'created_at', 'version', 'status_id',
+      'id', 'snapshot', 'plan_id', 'created_at', 'version', 'status_id','user_id',
     ].map(f => `${PlanSnapshot.table}.${f}`);
   }
 

--- a/src/router/controllers_v1/PlanVersionController.js
+++ b/src/router/controllers_v1/PlanVersionController.js
@@ -18,7 +18,7 @@ export default class PlanVersionController {
     const { planId } = params;
 
     checkRequiredFields(['planId'], 'params', req);
-
+    const userId = user.id
 
     try {
       const plan = await Plan.findById(db, planId);
@@ -29,7 +29,7 @@ export default class PlanVersionController {
       const agreementId = await Plan.agreementForPlanId(db, planId);
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const snapshot = await Plan.createSnapshot(db, planId);
+      const snapshot = await Plan.createSnapshot(db, planId,userId);
 
       return res.status(200).json(snapshot).end();
     } catch (error) {


### PR DESCRIPTION
Adding user_id to plan_snapshot to support some features and help with troubleshooting in general.  This will be used in the view that provides plan version attributes.