### PR TITLE
update migration to gracefully handle it already being applied to prod

### DIFF
--- a/src/libs/db2/migrations/20200403085035_update_plan_conf_from_client_agreement.js
+++ b/src/libs/db2/migrations/20200403085035_update_plan_conf_from_client_agreement.js
@@ -23,6 +23,7 @@
 exports.up = async function(knex) {
 
     const create_plan_conf_records = `
+    drop function if exists update_plan_conf_to_reflect_client_agreement() cascade;
     CREATE FUNCTION update_plan_conf_to_reflect_client_agreement() 
     RETURNS trigger as  $$
     BEGIN


### PR DESCRIPTION
we had to apply the client_agreement + plan_conf fix early so this should allow migrations to run smoothly when we do go to prod.