### PR TITLE
Fix migrations that use model functions

### DIFF
--- a/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
+++ b/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
@@ -1,5 +1,4 @@
 const Plan = require('../../../../build/src/libs/db2/model/plan').default;
-const PlanSnapshot = require('../../../../build/src/libs/db2/model/plansnapshot').default;
 const Agreement = require('../../../../build/src/libs/db2/model/agreement').default;
 
 exports.up = async (knex) => {

--- a/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
+++ b/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
@@ -53,15 +53,16 @@ exports.up = async (knex) => {
 
         await plan.eagerloadAllOneToMany();
 
-        const snapshot = await PlanSnapshot.create(knex, {
-          snapshot: JSON.stringify({ ...plan, agreement }),
-          created_at: versionRecord.created_at,
-          version: versionRecord.version,
-          plan_id: currentPlanId,
-          status_id: plan.statusId,
-        });
-
-        return snapshot;
+        await knex.raw(`
+          INSERT INTO plan_snapshot (snapshot, created_at, version, plan_id, status_id)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `, [
+          JSON.stringify({ ...plan, agreement }),
+          versionRecord.created_at,
+          versionRecord.version,
+          currentPlanId,
+          plan.statusId,
+        ]);
       });
 
       const snapshots = await Promise.all(snapshotsP);

--- a/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
+++ b/src/libs/db2/migrations/20200207115337_move-versions-to-snapshot.js
@@ -55,7 +55,7 @@ exports.up = async (knex) => {
 
         await knex.raw(`
           INSERT INTO plan_snapshot (snapshot, created_at, version, plan_id, status_id)
-          VALUES (?, ?, ?, ?, ?, ?)
+          VALUES (?, ?, ?, ?, ?)
         `, [
           JSON.stringify({ ...plan, agreement }),
           versionRecord.created_at,

--- a/src/libs/db2/migrations/20200303122440_remove-duplicates.js
+++ b/src/libs/db2/migrations/20200303122440_remove-duplicates.js
@@ -79,7 +79,7 @@ exports.up = async (knex) => {
               ...plan,
               agreement,
             }),
-            plan.created_at ?? null,
+            plan.created_at || null,
             lastVersion + (1 * i) + 1,
             currentPlan.plan_id,
             plan.statusId,

--- a/src/libs/db2/migrations/20200303122440_remove-duplicates.js
+++ b/src/libs/db2/migrations/20200303122440_remove-duplicates.js
@@ -1,5 +1,4 @@
 const Plan = require('../../../../build/src/libs/db2/model/plan').default;
-const PlanSnapshot = require('../../../../build/src/libs/db2/model/plansnapshot').default;
 const Agreement = require('../../../../build/src/libs/db2/model/agreement').default;
 
 exports.up = async (knex) => {
@@ -72,23 +71,24 @@ exports.up = async (knex) => {
             [currentPlan.plan_id],
           );
 
-          const snapshot = await PlanSnapshot.create(knex, {
-            snapshot: JSON.stringify({
+          await knex.raw(`
+            INSERT INTO plan_snapshot (snapshot, created_at, version, plan_id, status_id)
+            VALUES (?, ?, ?, ?, ?)
+          `, [
+            JSON.stringify({
               ...plan,
               agreement,
             }),
-            created_at: plan.created_at,
-            version: lastVersion + (1 * i) + 1,
-            plan_id: currentPlan.plan_id,
-            status_id: plan.statusId,
-          });
+            plan.created_at,
+            lastVersion + (1 * i) + 1,
+            currentPlan.plan_id,
+            plan.statusId,
+          ]);
 
           console.log(`Deleting plan ${id}`);
 
           await knex.raw('DELETE FROM plan_version WHERE plan_id=?', [id]);
           await knex.raw('DELETE FROM plan WHERE id=?', [id]);
-
-          return snapshot;
         }
       }
     }),

--- a/src/libs/db2/migrations/20200303122440_remove-duplicates.js
+++ b/src/libs/db2/migrations/20200303122440_remove-duplicates.js
@@ -79,7 +79,7 @@ exports.up = async (knex) => {
               ...plan,
               agreement,
             }),
-            plan.created_at,
+            plan.created_at ?? null,
             lastVersion + (1 * i) + 1,
             currentPlan.plan_id,
             plan.statusId,

--- a/src/libs/db2/migrations/20200325093633_retroactively-add-agreement-to-snapshots.js
+++ b/src/libs/db2/migrations/20200325093633_retroactively-add-agreement-to-snapshots.js
@@ -1,4 +1,3 @@
-const PlanSnapshot = require('../../../../build/src/libs/db2/model/plansnapshot').default;
 const Agreement = require('../../../../build/src/libs/db2/model/agreement').default;
 
 exports.up = async (knex) => {
@@ -18,9 +17,9 @@ exports.up = async (knex) => {
 
       const newSnapshot = { ...snapshot, agreement };
 
-      await PlanSnapshot.update(knex, { id }, {
-        snapshot: JSON.stringify(newSnapshot),
-      });
+      await knex.raw(`
+        UPDATE plan_snapshot SET snapshot=? WHERE id=?
+      `, [JSON.stringify(newSnapshot), id]);
     }
   });
 

--- a/src/libs/db2/migrations/20200401134337_create-existing-client-links.js
+++ b/src/libs/db2/migrations/20200401134337_create-existing-client-links.js
@@ -6,6 +6,10 @@ exports.up = async (knex) => {
 
   await Promise.all(
     userAccounts.map(async (user) => {
+      if (userAccounts.filter(u => u.client_id === user.client_id).length > 1) {
+        console.warn(`There are multiple users linked to client ID ${user.client_id}. Skipping creation of link to user ID ${user.id}`);
+        return;
+      }
       const result = await knex.raw(`
         INSERT INTO active_client_account(user_id, client_id, type, active)
         VALUES (?, ?, ?, ?);


### PR DESCRIPTION
I've tried to replace as many of the uses of model methods with raw queries to help future-proof our migrations. 

Relates to #179