### PR TITLE
Change get plan to pull privacy version

### DIFF
--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -55,7 +55,7 @@ export default class PlanController {
         { plan_id: planId },
       )[0];//todo figure out how to get last one from here
         
-/*
+        
       const [agreement] = await Agreement.findWithTypeZoneDistrictExemption(
         db, { forest_file_id: agreementId },
       );
@@ -63,7 +63,7 @@ export default class PlanController {
       agreement.transformToV1();
 
         
-      const versionData;
+      var versionData;
       if(shouldBeLiveVersionForStaff || shouldBeLiveVersionForAH)
       {
             await plan.eagerloadAllOneToMany();
@@ -72,9 +72,8 @@ export default class PlanController {
       {
             versionData = await PlanSnapshot.findOne(
             db,
-            { plan_id: planId, version },
+            { plan_id: planId, last_version },
       ); }
-      */
 
       plan.agreement = agreement;
 

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -32,11 +32,18 @@ export default class PlanController {
     );
 
     try {
+
       const [plan] = await Plan.findWithStatusExtension(db, { 'plan.id': planId }, ['id', 'desc']);
       if (!plan) {
         throw errorWithCode('Plan doesn\'t exist', 404);
       }
       const { agreementId } = plan;
+
+      const { status_id } = plan.status.id
+      const { isStaff } = user.isAdministrator()? true : user.isRangeOfficer? true : false;
+      const { isAH } user.isAgreementHolder()? true : false;
+
+
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
       const [agreement] = await Agreement.findWithTypeZoneDistrictExemption(

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -43,6 +43,10 @@ export default class PlanController {
       const { isStaff } = user.isAdministrator()? true : user.isRangeOfficer? true : false;
       const { isAH } user.isAgreementHolder()? true : false;
 
+      const { shouldBeLiveVersionForStaff } = ([6,13,14,15,16,12].includes(status_id) && isStaff)   
+        //redundant, but putting here to be explicit:
+      const { shouldBeLiveVersionForAH } = ([1,4,5,18,19,10].includes(status_id) && isAH)   
+
 
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -3,6 +3,7 @@ import { checkRequiredFields, objPathToCamelCase } from '../../libs/utils';
 import DataManager from '../../libs/db2';
 import config from '../../config';
 import { PlanRouteHelper } from '../helpers';
+import PlanSnapshot from '../../libs/db2/model/plansnapshot';
 
 const dm = new DataManager(config);
 const {
@@ -12,7 +13,6 @@ const {
   PlanConfirmation,
   PlanStatus,
   AdditionalRequirement,
-  PlanSnapshot,
 } = dm;
 
 export default class PlanController {
@@ -54,8 +54,8 @@ export default class PlanController {
         db,
         { plan_id: planId },
       )[0];//todo figure out how to get last one from here
-
-        /*
+        
+/*
       const [agreement] = await Agreement.findWithTypeZoneDistrictExemption(
         db, { forest_file_id: agreementId },
       );

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -50,10 +50,17 @@ export default class PlanController {
 
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const last_version = await PlanSnapshot.find(
+      const versions = await PlanSnapshot.find(
         db,
         { plan_id: planId },
-      )[0];//todo figure out how to get last one from here
+      );//todo figure out how to get last one from here
+        /*
+      if(versions.length() === 0){
+        throw errorWithCode('Plan doesn\'t exist o', 404);
+        */
+
+
+        logger.info(JSON.stringify(versions));
         
         
       const [agreement] = await Agreement.findWithTypeZoneDistrictExemption(

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -36,33 +36,33 @@ export default class PlanController {
 
       const [plan] = await Plan.findWithStatusExtension(db, { 'plan.id': planId }, ['id', 'desc']);
       if (!plan) {
-        throw errorWithCode('Plan doesn\'t exist o', 404);
+        throw errorWithCode('Plan doesn\'t exist', 404);
       }
+        logger.info(JSON.stringify(plan))
+
       const { agreementId } = plan;
+      const  status_id  = plan.status["id"];
 
-      const { status_id } = plan.status.id
-      const { isStaff } = user.isAdministrator()? true : user.isRangeOfficer? true : false;
-      const { isAH }  = user.isAgreementHolder()? true : false;
+      const  isStaff = user.isAdministrator()? true : user.isRangeOfficer? true : false;
+      const  isAH = user.isAgreementHolder()? true : false;
 
-      const { shouldBeLiveVersionForStaff } = ([6,13,14,15,16,12].includes(status_id) && isStaff)   
+      const shouldBeLiveVersionForStaff = ([6,13,14,15,16,12].includes(status_id) && isStaff)   
         //redundant, but putting here to be explicit:
-      const { shouldBeLiveVersionForAH } = ([1,4,5,18,19,10].includes(status_id) && isAH)   
+      const shouldBeLiveVersionForAH = ([1,4,5,18,19,10].includes(status_id) && isAH)   
 
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const versions = await PlanSnapshot.find(
+      /*
+        const versions = await PlanSnapshot.find(
         db,
         { plan_id: planId },
       );//todo figure out how to get last one from here
-        /*
+      
       if(versions.length() === 0){
         throw errorWithCode('Plan doesn\'t exist o', 404);
+
         */
 
-
-        logger.info(JSON.stringify(versions));
-        
-        
       const [agreement] = await Agreement.findWithTypeZoneDistrictExemption(
         db, { forest_file_id: agreementId },
       );
@@ -77,10 +77,13 @@ export default class PlanController {
       }
       else
       {
-            versionData = await PlanSnapshot.findOne(
+        logger.info('was never there')
+          /*  versionData = await PlanSnapshot.findOne(
             db,
-            { plan_id: planId, last_version },
-      ); }
+            { plan_id: planId, version: 1 },
+
+      ); */
+      }
 
       plan.agreement = agreement;
 

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -91,7 +91,10 @@ export default class PlanController {
       {
         logger.info('loading last version')
 
-          privacyVersion;
+          delete privacyVersion.status;
+          privacyVersion.status = plan.status;
+          delete privacyVersion.status_id;
+          privacyVersion.status_id = status_id;
           logger.info(JSON.stringify(privacyVersion));
           return res.status(200).json({
               ...privacyVersion

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -42,7 +42,7 @@ export default class PlanController {
 
       const { status_id } = plan.status.id
       const { isStaff } = user.isAdministrator()? true : user.isRangeOfficer? true : false;
-      const { isAH } user.isAgreementHolder()? true : false;
+      const { isAH }  = user.isAgreementHolder()? true : false;
 
       const { shouldBeLiveVersionForStaff } = ([6,13,14,15,16,12].includes(status_id) && isStaff)   
         //redundant, but putting here to be explicit:
@@ -50,15 +50,16 @@ export default class PlanController {
 
       await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
 
-      const versions = await PlanSnapshot.find(
+      const last_version = await PlanSnapshot.find(
         db,
         { plan_id: planId },
-      );
+      )[0];//todo figure out how to get last one from here
 
+        /*
       const [agreement] = await Agreement.findWithTypeZoneDistrictExemption(
         db, { forest_file_id: agreementId },
       );
-      await agreement.eagerloadAllOneToManyExceptPlan();
+      await agreement.eagerloadAllOneToManyExceptPlan();//todo determine if this matters 
       agreement.transformToV1();
 
         
@@ -72,10 +73,9 @@ export default class PlanController {
             versionData = await PlanSnapshot.findOne(
             db,
             { plan_id: planId, version },
-      );
+      ); }
+      */
 
-
-      }
       plan.agreement = agreement;
 
       const mappedGrazingSchedules = await Promise.all(

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -36,7 +36,7 @@ export default class PlanController {
 
       const [plan] = await Plan.findWithStatusExtension(db, { 'plan.id': planId }, ['id', 'desc']);
       if (!plan) {
-        throw errorWithCode('Plan doesn\'t exist', 404);
+        throw errorWithCode('Plan doesn\'t exist o', 404);
       }
       const { agreementId } = plan;
 

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -43,7 +43,7 @@ export default class PlanController {
       const { agreementId } = plan;
       const  status_id  = plan.status["id"];
 
-      const  isStaff = user.isAdministrator()? true : user.isRangeOfficer? true : false;
+      const  isStaff = user.isAdministrator()? true : user.isRangeOfficer()? true : false;
       const  isAH = user.isAgreementHolder()? true : false;
 
       const shouldBeLiveVersionForStaff = ([6,13,14,15,16,12].includes(status_id) && isStaff)   
@@ -73,16 +73,19 @@ export default class PlanController {
       var versionData;
       if(shouldBeLiveVersionForStaff || shouldBeLiveVersionForAH)
       {
+          logger.info('loading live plan')
             await plan.eagerloadAllOneToMany();
       }
       else
       {
-        logger.info('was never there')
-          /*  versionData = await PlanSnapshot.findOne(
-            db,
-            { plan_id: planId, version: 1 },
+        logger.info('loading last version')
 
-      ); */
+        const versions = await PlanSnapshot.find(
+        db,
+        { plan_id: planId },
+      );//todo figure out how to get last one from here
+          logger.info(JSON.stringify(versions));
+      
       }
 
       plan.agreement = agreement;


### PR DESCRIPTION
The `plan_snapshot_summary` table has a `privacyview` column that is either `null` for all versions of a plan (indicating all parties should see the live RUP), or one version for a given plan with be either `StaffView` or `AHView`, indicating this is the content (but not status) that should be loaded for Staff or AH at any given stage of the process.

This change is to make the `GET plan` endpoint observe this database column, and over ride the status information so the right buttons and headers are visible.

Rest of back end changes for bcgov/range-web#683