### PR TITLE
Fix snapshot deduplication logic

### DIFF
--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -64,7 +64,7 @@ export default class Plan extends Model {
     this.creator = new User(User.extract(data));
   }
 
-  static legalStatuses = [20, 8, 9, 12]
+  static legalStatuses = [20, 8, 9, 12, 21]
 
   static get fields() {
     // TODO:(jl) Work with consumers to remove 'agreement_id' from the selected

--- a/src/router/controllers_v1/PlanStatusController.js
+++ b/src/router/controllers_v1/PlanStatusController.js
@@ -50,17 +50,19 @@ export default class PlanStatusController {
           break;
       }
 
-        if(!([20, 8, 9, 12].includes((await Plan.find(db, { id: planId })).statusId)) && !([20, 8, 9, 12].includes(status.id)))
-        {
-            const snapshot = await Plan.createSnapshot(db, planId,user.id);
-        }
+      // Don't create a snapshot if the plan we're updating the status for
+      // already has a legal status
+      const originalPlan = await Plan.findById(db, planId);
+      if (!Plan.isLegal(originalPlan)) {
+        await Plan.createSnapshot(db, planId, user.id);
+      }
 
       const updatedPlan = await Plan.update(db, { id: planId }, body);
 
-        if([20, 8, 9, 12].includes(status.id))
-        {
-            const snapshot = await Plan.createSnapshot(db, planId,user.id);
-        }
+      // If the new status was legal, create a snapshot after updating
+      if (Plan.isLegal(updatedPlan)) {
+        await Plan.createSnapshot(db, planId, user.id);
+      }
 
       return updatedPlan;
     } catch (err) {


### PR DESCRIPTION
Basically, needed to replace `Plan.find` with `Plan.findOne` since `find` returns an array of plans.

