### PR TITLE
Add amendment attributes to plan_snapshot_summary

### DIFF
--- a/src/libs/db2/migrations/20200511091953_add_version_amendment_attributes.js
+++ b/src/libs/db2/migrations/20200511091953_add_version_amendment_attributes.js
@@ -1,8 +1,239 @@
 
-exports.up = function(knex) {
+exports.up = async (knex) => {
+  await knex.raw(`
+drop view if exists plan_snapshot_summary;
+create view plan_snapshot_summary as (
+WITH all_snapshots AS (
+  SELECT 
+    id, 
+    version, 
+    snapshot, 
+    Cast(snapshot ->> 'statusId' AS INTEGER) AS snapshot_status_id, 
+    plan_id, 
+    created_at, 
+    user_id, 
+    is_discarded 
+  FROM 
+    plan_snapshot
+), 
+max_version_of_plan AS (
+  SELECT 
+    Max(version) AS version, 
+    plan_id 
+  FROM 
+    all_snapshots 
+  GROUP BY 
+    plan_id
+), 
+max_version_of_plan_in_each_status AS (
+  SELECT 
+    Max(version) AS version, 
+    plan_id, 
+    snapshot_status_id 
+  FROM 
+    all_snapshots 
+  GROUP BY 
+    plan_id, 
+    snapshot_status_id
+), 
+most_recent_snapshot_of_each_status AS (
+  SELECT 
+    als.id, 
+    als.snapshot_status_id, 
+    als.plan_id, 
+    als.version 
+  FROM 
+    max_version_of_plan_in_each_status mr 
+    INNER JOIN all_snapshots als ON mr.plan_id = als.plan_id 
+    AND mr.version = als.version 
+  ORDER BY 
+    plan_id ASC, 
+    version DESC
+), 
+snapshots_with_legal_statuses AS (
+  SELECT 
+    all_snapshots.id, 
+    all_snapshots.plan_id, 
+    all_snapshots.created_at, 
+    all_snapshots.version,
+    all_snapshots.snapshot_status_id,
+    Row_number() OVER (
+      ORDER BY 
+        plan_id, 
+        version ASC
+    ) AS legal_version 
+  FROM 
+    all_snapshots 
+  WHERE 
+    all_snapshots.snapshot_status_id IN (20, 8, 9, 12, 21) 
+    AND all_snapshots.is_discarded = false
+), 
+legal_snapshot_summary AS (
+  SELECT 
+    swl.id, 
+    swl.created_at AS effective_legal_start, 
+    swl.snapshot_status_id,
+    CASE WHEN EXISTS (
+      SELECT 
+        id 
+      FROM 
+        snapshots_with_legal_statuses 
+      WHERE 
+        plan_id = swl.plan_id 
+        AND legal_version = (swl.legal_version + 1)
+    ) THEN (
+      SELECT 
+        created_at 
+      FROM 
+        snapshots_with_legal_statuses 
+      WHERE 
+        plan_id = swl.plan_id 
+        AND legal_version = (swl.legal_version + 1)
+    ) ELSE NULL END AS effective_legal_end 
+  FROM 
+    snapshots_with_legal_statuses swl
+), 
+privacy_versions AS (
+  SELECT 
+    als.id, 
+    CASE 
+	--when in AH draft
+	WHEN 	EXISTS ( SELECT id 	FROM 	PLAN p 
+					WHERE 	als.plan_id = id 
+					AND 	status_id = 1 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) is null) 
+	    	AND als.snapshot_status_id = 6 
+	    	AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	-- agreement holder submits back
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 13) 
+    		AND als.snapshot_status_id = 1 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'AHView' 
+
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 5) 
+    		AND als.snapshot_status_id = 13 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+	
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 19) 
+    		AND als.snapshot_status_id = 13 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 18) 
+    		AND als.snapshot_status_id = 13 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	--staff mandatory initiated
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 22) 
+    		AND EXISTS ( SELECT id 	FROM 	legal_snapshot_summary 
+					WHERE 	id = als.id 
+						and effective_legal_start is not null 
+						and effective_legal_end is null) 
+	THEN 'AHView' 
+
+	--staff mandatory kicked to AH court
+	WHEN 	EXISTS ( SELECT id 	FROM 	PLAN p 
+					WHERE 	als.plan_id = id 
+					AND 	status_id = 1 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) = 2) 
+    		AND als.snapshot_status_id = 22 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	--staff mandatory getting signed
+	WHEN 	EXISTS ( SELECT id 	FROM 	PLAN p 
+					WHERE 	als.plan_id = id 
+					AND 	status_id = 18 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) = 2) 
+    		AND als.snapshot_status_id = 22 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	--ah minor initiated
+	WHEN 	EXISTS ( SELECT id FROM PLAN p 
+			           WHERE als.plan_id = id 
+				   AND status_id = 23)
+    		AND EXISTS ( SELECT id 	FROM 	legal_snapshot_summary 
+					WHERE 	id = als.id 
+						and effective_legal_start is not null 
+						and effective_legal_end is null) 
+	THEN 'StaffView' 
+
+	--ah minor awaiting signatures
+	WHEN 	EXISTS ( SELECT id FROM PLAN p 
+			           WHERE als.plan_id = id 
+				   AND status_id = 18 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) = 1) 
+    		AND EXISTS ( SELECT id 	FROM 	legal_snapshot_summary 
+					WHERE 	id = als.id 
+						and effective_legal_start is not null 
+						and effective_legal_end is null) 
+	THEN 'StaffView' 
+	ELSE NULL
+    END AS privacyView 
+  FROM 
+    all_snapshots als
+),
+legal_version_reason as (
+	with associated_legal_versions as (
+	  select 
+	    als.id, 
+	    als.plan_id, 
+	    als.version, 
+	    swl.id as associated_legal_id 
+	  from 
+	    all_snapshots als 
+	    left join snapshots_with_legal_statuses swl on als.version <= swl.version 
+	    and als.plan_id = swl.plan_id 
+	    and (
+	      als.version > coalesce(
+		(
+		  select 
+		    swl2.version 
+		  from 
+		    snapshots_with_legal_statuses swl2 
+		  where 
+		    swl2.plan_id = swl.plan_id 
+		    and swl2.legal_version = (swl.legal_version - 1) 
+		    or swl2.legal_version = null
+		), 
+		0
+	      )
+	    )
+	) 
+	select * from associated_legal_versions
+),
+endpoint_query as (
+SELECT 
+  all_snapshots.id, 
+  all_snapshots.snapshot, 
+  all_snapshots.plan_id, 
+  all_snapshots.created_at, 
+  all_snapshots.version, 
+  all_snapshots.snapshot_status_id AS status_id, 
+  all_snapshots.user_id, 
+  last_snapshot.snapshot_status_id AS from_status_id, 
+  all_snapshots.snapshot_status_id AS to_status_id, 
+  legal_snapshot_summary.effective_legal_start, 
+  legal_snapshot_summary.effective_legal_end, 
+  privacy_versions.privacyview 
+FROM 
+  all_snapshots 
+  LEFT JOIN legal_snapshot_summary ON legal_snapshot_summary.id = all_snapshots.id 
+  LEFT JOIN all_snapshots last_snapshot ON all_snapshots.plan_id = last_snapshot.plan_id 
+  AND all_snapshots.version = (last_snapshot.version + 1) 
+  LEFT JOIN privacy_versions ON privacy_versions.id = all_snapshots.id 
+  JOIN PLAN p ON p.id = all_snapshots.plan_id
+)
+select legal_version_reason.*, als.snapshot_status_id from legal_version_reason 
+join all_snapshots als on als.id = legal_version_reason.id where legal_version_reason.plan_id = 204 order by legal_version_reason.version asc
+);`)
   
 };
-
 
 exports.down = async (knex) => {
   await knex.raw(`

--- a/src/libs/db2/migrations/20200511091953_add_version_amendment_attributes.js
+++ b/src/libs/db2/migrations/20200511091953_add_version_amendment_attributes.js
@@ -1,0 +1,207 @@
+
+exports.up = function(knex) {
+  
+};
+
+
+exports.down = async (knex) => {
+  await knex.raw(`
+drop view if exists plan_snapshot_summary;
+create view plan_snapshot_summary as (
+WITH all_snapshots AS (
+  SELECT 
+    id, 
+    version, 
+    snapshot, 
+    Cast(snapshot ->> 'statusId' AS INTEGER) AS snapshot_status_id, 
+    plan_id, 
+    created_at, 
+    user_id, 
+    is_discarded 
+  FROM 
+    plan_snapshot
+), 
+max_version_of_plan AS (
+  SELECT 
+    Max(version) AS version, 
+    plan_id 
+  FROM 
+    all_snapshots 
+  GROUP BY 
+    plan_id
+), 
+max_version_of_plan_in_each_status AS (
+  SELECT 
+    Max(version) AS version, 
+    plan_id, 
+    snapshot_status_id 
+  FROM 
+    all_snapshots 
+  GROUP BY 
+    plan_id, 
+    snapshot_status_id
+), 
+most_recent_snapshot_of_each_status AS (
+  SELECT 
+    als.id, 
+    als.snapshot_status_id, 
+    als.plan_id, 
+    als.version 
+  FROM 
+    max_version_of_plan_in_each_status mr 
+    INNER JOIN all_snapshots als ON mr.plan_id = als.plan_id 
+    AND mr.version = als.version 
+  ORDER BY 
+    plan_id ASC, 
+    version DESC
+), 
+snapshots_with_legal_statuses AS (
+  SELECT 
+    all_snapshots.id, 
+    all_snapshots.plan_id, 
+    all_snapshots.created_at, 
+    all_snapshots.snapshot_status_id,
+    Row_number() OVER (
+      ORDER BY 
+        plan_id, 
+        version ASC
+    ) AS legal_version 
+  FROM 
+    all_snapshots 
+  WHERE 
+    all_snapshots.snapshot_status_id IN (20, 8, 9, 12, 21) 
+    AND all_snapshots.is_discarded = false
+), 
+legal_snapshot_summary AS (
+  SELECT 
+    swl.id, 
+    swl.created_at AS effective_legal_start, 
+    swl.snapshot_status_id,
+    CASE WHEN EXISTS (
+      SELECT 
+        id 
+      FROM 
+        snapshots_with_legal_statuses 
+      WHERE 
+        plan_id = swl.plan_id 
+        AND legal_version = (swl.legal_version + 1)
+    ) THEN (
+      SELECT 
+        created_at 
+      FROM 
+        snapshots_with_legal_statuses 
+      WHERE 
+        plan_id = swl.plan_id 
+        AND legal_version = (swl.legal_version + 1)
+    ) ELSE NULL END AS effective_legal_end 
+  FROM 
+    snapshots_with_legal_statuses swl
+), 
+privacy_versions AS (
+  SELECT 
+    als.id, 
+    CASE 
+	--when in AH draft
+	WHEN 	EXISTS ( SELECT id 	FROM 	PLAN p 
+					WHERE 	als.plan_id = id 
+					AND 	status_id = 1 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) is null) 
+	    	AND als.snapshot_status_id = 6 
+	    	AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	-- agreement holder submits back
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 13) 
+    		AND als.snapshot_status_id = 1 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'AHView' 
+
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 5) 
+    		AND als.snapshot_status_id = 13 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+	
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 19) 
+    		AND als.snapshot_status_id = 13 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 18) 
+    		AND als.snapshot_status_id = 13 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	--staff mandatory initiated
+	WHEN 	EXISTS ( SELECT id FROM PLAN p WHERE als.plan_id = id AND status_id = 22) 
+    		AND EXISTS ( SELECT id 	FROM 	legal_snapshot_summary 
+					WHERE 	id = als.id 
+						and effective_legal_start is not null 
+						and effective_legal_end is null) 
+	THEN 'AHView' 
+
+	--staff mandatory kicked to AH court
+	WHEN 	EXISTS ( SELECT id 	FROM 	PLAN p 
+					WHERE 	als.plan_id = id 
+					AND 	status_id = 1 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) = 2) 
+    		AND als.snapshot_status_id = 22 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	--staff mandatory getting signed
+	WHEN 	EXISTS ( SELECT id 	FROM 	PLAN p 
+					WHERE 	als.plan_id = id 
+					AND 	status_id = 18 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) = 2) 
+    		AND als.snapshot_status_id = 22 
+    		AND EXISTS ( SELECT id FROM most_recent_snapshot_of_each_status WHERE id = als.id) 
+	THEN 'StaffView' 
+
+	--ah minor initiated
+	WHEN 	EXISTS ( SELECT id FROM PLAN p 
+			           WHERE als.plan_id = id 
+				   AND status_id = 23)
+    		AND EXISTS ( SELECT id 	FROM 	legal_snapshot_summary 
+					WHERE 	id = als.id 
+						and effective_legal_start is not null 
+						and effective_legal_end is null) 
+	THEN 'StaffView' 
+
+	--ah minor awaiting signatures
+	WHEN 	EXISTS ( SELECT id FROM PLAN p 
+			           WHERE als.plan_id = id 
+				   AND status_id = 18 
+					and 	Cast(als.snapshot ->> 'amendmentTypeId' AS INTEGER) = 1) 
+    		AND EXISTS ( SELECT id 	FROM 	legal_snapshot_summary 
+					WHERE 	id = als.id 
+						and effective_legal_start is not null 
+						and effective_legal_end is null) 
+	THEN 'StaffView' 
+	ELSE NULL
+    END AS privacyView 
+  FROM 
+    all_snapshots als
+) 
+SELECT 
+  all_snapshots.id, 
+  all_snapshots.snapshot, 
+  all_snapshots.plan_id, 
+  all_snapshots.created_at, 
+  all_snapshots.version, 
+  all_snapshots.snapshot_status_id AS status_id, 
+  all_snapshots.user_id, 
+  last_snapshot.snapshot_status_id AS from_status_id, 
+  all_snapshots.snapshot_status_id AS to_status_id, 
+  legal_snapshot_summary.effective_legal_start, 
+  legal_snapshot_summary.effective_legal_end, 
+  privacy_versions.privacyview 
+FROM 
+  all_snapshots 
+  LEFT JOIN legal_snapshot_summary ON legal_snapshot_summary.id = all_snapshots.id 
+  LEFT JOIN all_snapshots last_snapshot ON all_snapshots.plan_id = last_snapshot.plan_id 
+  AND all_snapshots.version = (last_snapshot.version + 1) 
+  LEFT JOIN privacy_versions ON privacy_versions.id = all_snapshots.id 
+  JOIN PLAN p ON p.id = all_snapshots.plan_id
+);`)
+  
+};

--- a/src/libs/db2/migrations/20200511091953_add_version_amendment_attributes.js
+++ b/src/libs/db2/migrations/20200511091953_add_version_amendment_attributes.js
@@ -252,7 +252,7 @@ legal_version_reason as (
 	from associated_legal_versions av
 	left join legal_reason_summary lr on lr.associated_legal_id = av.associated_legal_id
 	
-),
+)
 SELECT 
   all_snapshots.id, 
   all_snapshots.snapshot, 


### PR DESCRIPTION
The `plan_snapshot_summary` view will work out what type of plan is being worked on for any given version, be it an in progress RUP, agreement holder minor amendment, etc.  This info will be used in the UI to show where legal versions came from.

At this point it can only figure it out for things followed by a legal version, so it's not quite ready to drive plan status history but could potentially do that with some more work.

#203 