### PR TITLE
Remove filtering for plans in WM - without effect

### DIFF
--- a/src/libs/db2/model/agreement.js
+++ b/src/libs/db2/model/agreement.js
@@ -266,9 +266,7 @@ export default class Agreement extends Model {
     // if latestPlan && staffDraft returns the most recent plan except the one whose status is staff draft
     // if latestPlan && !staffDraft returns the most recent plan
     if (latestPlan) {
-      const planStatusWhere = staffDraft
-        ? { code: PLAN_STATUS.WRONGLY_MADE_WITHOUT_EFFECT }
-        : { code: [PLAN_STATUS.WRONGLY_MADE_WITHOUT_EFFECT, PLAN_STATUS.STAFF_DRAFT] };
+      const planStatusWhere = staffDraft && { code: [PLAN_STATUS.STAFF_DRAFT] };
       const notAllowedStatuses = await PlanStatus.find(this.db, planStatusWhere);
       const whereNot = ['status_id', 'not in', notAllowedStatuses.map(s => s.id)];
       plans = await Plan.findWithStatusExtension(this.db, where, order, 1, 1, whereNot);


### PR DESCRIPTION
Seems like the agreements endpoint was filtering out plans with a status of "Wrongly Made  - Without Effect". I'm not sure exactly why, but I think it was related to the original implementation of amendments/versioning.
