### PR TITLE
Track if plan is restored

### DIFF
--- a/src/libs/db2/migrations/20200514085211_add-is-restored-column-to-plan.js
+++ b/src/libs/db2/migrations/20200514085211_add-is-restored-column-to-plan.js
@@ -1,0 +1,13 @@
+exports.up = async (knex) => {
+  await knex.raw(`
+    ALTER TABLE plan
+      ADD COLUMN is_restored BOOL DEFAULT FALSE;
+  `);
+};
+
+exports.down = async (knex) => {
+  await knex.raw(`
+    ALTER TABLE plan
+      DROP COLUMN is_restored;
+  `);
+};

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -209,7 +209,7 @@ export default class Plan extends Model {
 
     const { snapshot } = planSnapshot;
 
-    await Plan.update(db, { id: planId }, snapshot);
+    await Plan.update(db, { id: planId }, { ...snapshot, isRestored: true });
 
     await Pasture.remove(db, { plan_id: planId });
     const pasturePromises = snapshot.pastures.map(async (pasture) => {

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -156,7 +156,7 @@ export default class Plan extends Model {
     return result.agreement_id;
   }
 
-  static async createSnapshot(db, planId,userId) {
+  static async createSnapshot(db, planId, userId) {
     const [plan] = await Plan.findWithStatusExtension(db, { 'plan.id': planId }, ['id', 'desc']);
     if (!plan) {
       throw errorWithCode('Plan doesn\'t exist', 404);
@@ -187,7 +187,7 @@ export default class Plan extends Model {
       created_at: new Date(),
       version: lastVersion + 1,
       status_id: plan.statusId,
-      user_id: userId
+      user_id: userId,
     });
 
     return snapshotRecord;

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -76,6 +76,7 @@ export default class Plan extends Model {
       'notes', 'alt_business_name', 'agreement_id', 'status_id',
       'uploaded', 'amendment_type_id', 'created_at', 'updated_at',
       'effective_at', 'submitted_at', 'creator_id', 'canonical_id',
+      'is_restored',
     ].map(f => `${Plan.table}.${f}`);
   }
 

--- a/src/router/controllers_v1/PlanStatusController.js
+++ b/src/router/controllers_v1/PlanStatusController.js
@@ -53,14 +53,14 @@ export default class PlanStatusController {
       // Don't create a snapshot if the plan we're updating the status for
       // already has a legal status
       const originalPlan = await Plan.findById(db, planId);
-      if (!Plan.isLegal(originalPlan)) {
+      if (!originalPlan.isRestored && !Plan.isLegal(originalPlan)) {
         await Plan.createSnapshot(db, planId, user.id);
       }
 
-      const updatedPlan = await Plan.update(db, { id: planId }, body);
+      const updatedPlan = await Plan.update(db, { id: planId }, { ...body, is_restored: false });
 
       // If the new status was legal, create a snapshot after updating
-      if (Plan.isLegal(updatedPlan)) {
+      if (!originalPlan.isRestored && Plan.isLegal(updatedPlan)) {
         await Plan.createSnapshot(db, planId, user.id);
       }
 


### PR DESCRIPTION
Adds a new `is_restored` column to `plan`. We set it to true when a snapshot is restored, and back to false whenever the plan's status is changed. When creating snapshots, we check to see if the plan is restored (meaning it already has a snapshot), and skip snapshotting if it is.