### PR TITLE
Allow db port to be specified by environment variable

### DIFF
--- a/e2e.docker-compose.yml
+++ b/e2e.docker-compose.yml
@@ -32,6 +32,8 @@ services:
      dockerfile: Dockerfile
      args:
       - PORT:${POSTGRESQL_PORT}
+    ports:
+      - 5433:5432
     environment:
      - POSTGRES_USER=${POSTGRESQL_USER}
      - POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD}

--- a/knexfile.js
+++ b/knexfile.js
@@ -13,6 +13,7 @@ module.exports = {
     client: 'postgresql',
     connection: {
       host: process.env.POSTGRESQL_HOST,
+      port: process.env.POSTGRESQL_PORT || 5432,
       database: process.env.POSTGRESQL_DATABASE_TEST,
       user: process.env.POSTGRESQL_USER,
       password: process.env.POSTGRESQL_PASSWORD,
@@ -31,6 +32,7 @@ module.exports = {
     client: 'postgresql',
     connection: {
       host: process.env.POSTGRESQL_HOST,
+      port: process.env.POSTGRESQL_PORT || 5432,
       database: process.env.POSTGRESQL_DATABASE,
       user: process.env.POSTGRESQL_USER,
       password: process.env.POSTGRESQL_PASSWORD,
@@ -55,6 +57,7 @@ module.exports = {
     client: 'postgresql',
     connection: {
       host: process.env.POSTGRESQL_HOST,
+      port: process.env.POSTGRESQL_PORT || 5432,
       database: process.env.POSTGRESQL_DATABASE,
       user: process.env.POSTGRESQL_USER,
       password: process.env.POSTGRESQL_PASSWORD,


### PR DESCRIPTION
This is necessary in order to allow the E2E database to run on a different port, so it doesn't interfere with the regular instance.