### PR TITLE
Agreement endpoint changes for agents

### DIFF
--- a/src/libs/db2/migrations/20200707093127_plan_confirmation-user_id.js
+++ b/src/libs/db2/migrations/20200707093127_plan_confirmation-user_id.js
@@ -1,0 +1,17 @@
+exports.up = async (knex) => {
+  await knex.raw(`
+    ALTER TABLE plan_confirmation
+      ADD COLUMN user_id INTEGER,
+      ADD FOREIGN KEY (user_id)
+        REFERENCES user_account(id),
+      ADD COLUMN is_own_signature BOOL DEFAULT true NOT NULL;
+  `);
+};
+
+exports.down = async (knex) => {
+  await knex.raw(`
+    ALTER TABLE plan_confirmation
+      DROP COLUMN user_id,
+      DROP COLUMN is_own_signature;
+  `);
+};

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -729,6 +729,12 @@ export default class Plan extends Model {
     const confirmations = await PlanConfirmation.find(
       this.db, { plan_id: this.id },
     );
+    for (const confirmation of confirmations) {
+      if (confirmation.userId) {
+        const user = await User.findOne(this.db, { id: confirmation.userId });
+        confirmation.user = user;
+      }
+    }
     this.confirmations = confirmations || [];
   }
 

--- a/src/libs/db2/model/planconfirmation.js
+++ b/src/libs/db2/model/planconfirmation.js
@@ -34,7 +34,7 @@ export default class PlanConfirmation extends Model {
   }
 
   static get fields() {
-    return ['id', 'plan_id', 'client_id', 'confirmed', 'created_at', 'updated_at'];
+    return ['id', 'plan_id', 'client_id', 'confirmed', 'created_at', 'updated_at', 'user_id', 'is_own_signature'];
   }
 
   static get table() {

--- a/src/libs/db2/model/user.js
+++ b/src/libs/db2/model/user.js
@@ -200,6 +200,7 @@ User.prototype.canAccessAgreement = async function(db, agreement) {
     const [result] = await db
       .table('client_agreement')
       .whereIn('client_agreement.client_id', clientIds)
+      .andWhere({ agreement_id: agreement.forestFileId })
       .orWhere('client_agreement.agent_id', this.id)
       .andWhere({ agreement_id: agreement.forestFileId })
       .count();

--- a/src/libs/db2/model/user.js
+++ b/src/libs/db2/model/user.js
@@ -200,6 +200,7 @@ User.prototype.canAccessAgreement = async function(db, agreement) {
     const [result] = await db
       .table('client_agreement')
       .whereIn('client_agreement.client_id', clientIds)
+      .orWhere('client_agreement.agent_id', this.id)
       .andWhere({ agreement_id: agreement.forestFileId })
       .count();
     const { count } = result || {};

--- a/src/router/routes_v1/client.js
+++ b/src/router/routes_v1/client.js
@@ -111,7 +111,7 @@ router.get('/agreements/:planId', asyncMiddleware(async (req, res) => {
     planId,
   } = req.params;
 
-  if (!req.user || req.user.isAgreementHolder()) {
+  if (!req.user) {
     throw errorWithCode('Unauthorized', 401);
   }
 
@@ -132,6 +132,8 @@ router.get('/agreements/:planId', asyncMiddleware(async (req, res) => {
         const agent = await User.findOne(db, { id: clientAgreement.agentId });
         clientAgreement.agent = agent;
       }
+
+      return clientAgreement;
     }),
   );
 


### PR DESCRIPTION
* Include agreements in `/search` endpoint where the user is an agent
* Adds `user_id` and `is_own_signature` column to `plan_confirmation`

Relates to https://github.com/bcgov/range-web/issues/633