### PR TITLE
Add file upload and plan attachment endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ close-db-test: ## -- Target : Runs the local development containers.
 
 run-db-test: ## -- Target : Runs the local development containers.
 	@echo "+\n++ Make: Running db for test locally...\n+"
-	@docker-compose -f test.docker-compose.yml -p myra-test up -d db
+	@docker-compose -f test.docker-compose.yml -p myra-test up -d db minio minio-nginx
 
 close-local: ## -- Target : Closes the local development containers.
 	@echo "+\n++ Make: Closing local container ...\n+"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - NODE_ENV=${ENVIRONMENT}
       - POSTGRESQL_PORT=${POSTGRESQL_PORT}
       - MINIO_ENDPOINT=minio
+      - MINIO_PUBLIC_ENDPOINT=localhost
+      - MINIO_PORT=9000
       - MINIO_ACCESS_KEY=minio
       - MINIO_SECRET_KEY=secretminiokey123
       - MINIO_BUCKET=myra-dev
@@ -52,7 +54,7 @@ services:
     volumes:
       - minio-data:/data/minio
     ports:
-      - 9000:9000
+      - 9000
     environment:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: secretminiokey123
@@ -63,6 +65,16 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    networks:
+      - local
+  minio-nginx:
+    image: nginx
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - 9000:9000
+    depends_on:
+      - minio
     networks:
       - local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - POSTGRESQL_HOST=${POSTGRESQL_HOST}
       - NODE_ENV=${ENVIRONMENT}
       - POSTGRESQL_PORT=${POSTGRESQL_PORT}
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=secretminiokey123
+      - MINIO_BUCKET=myra-dev
     networks:
       - local
   db:
@@ -43,6 +47,24 @@ services:
       - local
     volumes:
       - postgres:/var/lib/postgresql/data
+  minio:
+    image: minio/minio
+    volumes:
+      - minio-data:/data/minio
+    ports:
+      - 9000:9000
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: secretminiokey123
+      MINIO_DOMAIN: localhost 
+    command: server /data/minio 
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    networks:
+      - local
 
 networks:
   local:
@@ -51,3 +73,5 @@ networks:
 volumes:
   postgres:
     name: ${PROJECT}-${ENVIRONMENT}-vol-postgres
+  minio-data:
+    name: minio-data-dev

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,34 @@
+events {}
+http {
+  server {
+    listen 9000;
+    server_name localhost;
+
+    # To allow special characters in headers
+    ignore_invalid_headers off;
+    # Allow any size file to be uploaded.
+    # Set to a value such as 1000m; to restrict file size to a specific value
+    client_max_body_size 0;
+    # To disable buffering
+    proxy_buffering off;
+
+    location / {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host minio:9000;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      proxy_connect_timeout 300;
+      # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      chunked_transfer_encoding off;
+
+      proxy_pass        http://minio:9000;
+    } 
+  }
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1240,6 +1240,76 @@
         "request-promise-native": "^1.0.5",
         "rsa-pem-from-mod-exp": "^0.8.4",
         "winston": "^3.0.0"
+      },
+      "dependencies": {
+        "block-stream2": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-1.1.0.tgz",
+          "integrity": "sha1-xzjjqRupd+u14f70MeE8oR2GOeI=",
+          "requires": {
+            "defined": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          }
+        },
+        "es6-error": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-2.1.1.tgz",
+          "integrity": "sha1-kThDAexe0cmnJH0RKCRyFvA1R80="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minio": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/minio/-/minio-6.0.0.tgz",
+          "integrity": "sha1-flFNOOqs8iZFVrIy8cLAY8xsp7o=",
+          "requires": {
+            "async": "^1.5.2",
+            "block-stream2": "^1.0.0",
+            "concat-stream": "^1.4.8",
+            "es6-error": "^2.0.2",
+            "json-stream": "^1.0.0",
+            "lodash": "^4.14.2",
+            "mime-types": "^2.1.14",
+            "mkdirp": "^0.5.1",
+            "querystring": "0.2.0",
+            "source-map-support": "^0.4.12",
+            "through2": "^0.6.5",
+            "uuid": "^3.1.0",
+            "xml": "^1.0.0",
+            "xml2js": "^0.4.15"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -2333,13 +2403,23 @@
       }
     },
     "block-stream2": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-1.1.0.tgz",
-      "integrity": "sha1-xzjjqRupd+u14f70MeE8oR2GOeI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-2.0.0.tgz",
+      "integrity": "sha512-1oI+RHHUEo64xomy1ozLgVJetFlHkIfQfJzTBQrj6xWnEMEPooeo2fZoqFjp0yzfHMBrgxwgh70tKp6T17+i3g==",
       "requires": {
-        "defined": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bluebird": {
@@ -3524,9 +3604,9 @@
       }
     },
     "es6-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-2.1.1.tgz",
-      "integrity": "sha1-kThDAexe0cmnJH0RKCRyFvA1R80="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -7093,24 +7173,28 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minio": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/minio/-/minio-6.0.0.tgz",
-      "integrity": "sha1-flFNOOqs8iZFVrIy8cLAY8xsp7o=",
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/minio/-/minio-7.0.16.tgz",
+      "integrity": "sha512-OgCJ3XVMzukSqoMFBiBDeyz30BxYTBM9yRLVRBCExTb+QKVxJh4DnUOS2/zw7OPeDyXXEvYSzDvg4FkCf1Cxyw==",
       "requires": {
-        "async": "^1.5.2",
-        "block-stream2": "^1.0.0",
-        "concat-stream": "^1.4.8",
-        "es6-error": "^2.0.2",
+        "async": "^3.1.0",
+        "block-stream2": "^2.0.0",
+        "es6-error": "^4.1.1",
         "json-stream": "^1.0.0",
         "lodash": "^4.14.2",
         "mime-types": "^2.1.14",
         "mkdirp": "^0.5.1",
         "querystring": "0.2.0",
-        "source-map-support": "^0.4.12",
-        "through2": "^0.6.5",
-        "uuid": "^3.1.0",
+        "through2": "^3.0.1",
         "xml": "^1.0.0",
         "xml2js": "^0.4.15"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        }
       }
     },
     "mixin-deep": {
@@ -9365,35 +9449,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
+        "readable-stream": "2 || 3"
       }
     },
     "through2-filter": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jsonwebtoken": "^8.2.1",
     "knex": "^0.19.5",
     "lodash": "^4.17.13",
+    "minio": "^7.0.16",
     "moment": "^2.22.0",
     "nconf": "^0.10.0",
     "passport": "^0.4.0",

--- a/src/libs/db2/index.js
+++ b/src/libs/db2/index.js
@@ -62,6 +62,7 @@ import UserFeedback from './model/userfeedback';
 import Version from './model/version';
 import config from '../../config';
 import UserClientLink from './model/userclientlink';
+import PlanFile from './model/PlanFile';
 
 export const connection = knex({
   client: 'pg',
@@ -136,5 +137,6 @@ export default class DataManager {
     this.UserFeedback = UserFeedback;
     this.Version = Version;
     this.UserClientLink = UserClientLink;
+    this.PlanFile = PlanFile;
   }
 }

--- a/src/libs/db2/migrations/20200710093122_add-files-table.js
+++ b/src/libs/db2/migrations/20200710093122_add-files-table.js
@@ -1,0 +1,17 @@
+exports.up = async (knex) => {
+  await knex.raw(`
+    CREATE TABLE plan_file(
+      id SERIAL PRIMARY KEY NOT NULL,
+      name VARCHAR NOT NULL,
+      url VARCHAR NOT NULL,
+      type VARCHAR NOT NULL,
+      access VARCHAR NOT NULL DEFAULT 'staff_only',
+      plan_id INTEGER NOT NULL REFERENCES plan(id),
+      user_id INTEGER NOT NULL REFERENCES user_account(id)
+    );
+  `);
+};
+
+exports.down = async (knex) => {
+  await knex.raw('DROP TABLE plan_file');
+};

--- a/src/libs/db2/model/PlanFile.js
+++ b/src/libs/db2/model/PlanFile.js
@@ -1,0 +1,26 @@
+'use strict';
+
+import Model from './model';
+
+export default class PlanFile extends Model {
+  constructor(data, db = undefined) {
+    const obj = {};
+    Object.keys(data).forEach((key) => {
+      if (PlanFile.fields.indexOf(`${PlanFile.table}.${key}`) > -1) {
+        obj[key] = data[key];
+      }
+    });
+
+    super(obj, db);
+  }
+
+  static get fields() {
+    // primary key *must* be first!
+    return ['id', 'name', 'url', 'type', 'plan_id', 'user_id', 'access']
+      .map(field => `${this.table}.${field}`);
+  }
+
+  static get table() {
+    return 'plan_file';
+  }
+}

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -44,6 +44,7 @@ import MinisterIssueAction from './ministerissueaction';
 import MinisterIssuePasture from './ministerissuepasture';
 import PlanSnapshot from './plansnapshot';
 import Agreement from './agreement';
+import PlanFile from './PlanFile';
 
 export default class Plan extends Model {
   constructor(data, db = undefined) {
@@ -446,6 +447,16 @@ export default class Plan extends Model {
     );
 
     await Promise.all(newStatusHistoryPromises);
+
+    const filePromises = snapshot.files.map(
+      async (file) => {
+        const newFile = await PlanFile.create(db, file);
+
+        return newFile;
+      },
+    );
+
+    await Promise.all(filePromises);
   }
 
   static async duplicateAll(db, planId) {
@@ -723,6 +734,7 @@ export default class Plan extends Model {
     await this.fetchInvasivePlantChecklist();
     await this.fetchAdditionalRequirements();
     await this.fetchManagementConsiderations();
+    await this.fetchFiles();
   }
 
   async fetchPlanConfirmations() {
@@ -810,5 +822,12 @@ export default class Plan extends Model {
     const considerations = await ManagementConsideration.findWithType(this.db, where);
 
     this.managementConsiderations = considerations || [];
+  }
+
+  async fetchFiles() {
+    const where = { plan_id: this.id };
+    const planFiles = await PlanFile.find(this.db, where);
+
+    this.files = planFiles;
   }
 }

--- a/src/libs/db2/model/plan.js
+++ b/src/libs/db2/model/plan.js
@@ -828,6 +828,10 @@ export default class Plan extends Model {
     const where = { plan_id: this.id };
     const planFiles = await PlanFile.find(this.db, where);
 
+    for (const file of planFiles) {
+      file.user = await User.findById(this.db, file.userId)
+    }
+
     this.files = planFiles;
   }
 }

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -355,6 +355,29 @@ export default class PlanController {
     res.json(planFile).end();
   }
 
+  static async updateAttachment(req, res) {
+    const { params, user, body } = req;
+    const { planId, attachmentId } = params;
+
+    if (!user || !user.isRangeOfficer()) {
+      throw errorWithCode('Unauthorized', 403);
+    }
+
+    const agreementId = await Plan.agreementForPlanId(db, planId);
+
+    await PlanRouteHelper.canUserAccessThisAgreement(db, Agreement, user, agreementId);
+    const planFile = await PlanFile.findById(db, attachmentId);
+    if (!planFile) {
+      throw errorWithCode('Could not find file', 404);
+    }
+
+    const newPlanFile = await PlanFile.update(db, { id: attachmentId }, {
+      access: body.access ?? 'staff_only',
+    });
+
+    res.json(newPlanFile).end();
+  }
+
   static async removeAttachment(req, res) {
     const { params, user } = req;
     const { planId, attachmentId } = params;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -38,6 +38,7 @@ import user from './routes_v1/user';
 import zone from './routes_v1/zone';
 import feedback from './routes_v1/feedback';
 import version from './routes_v1/version';
+import upload from './routes_v1/upload';
 
 const corsOptions = {
   // origin: config.get('appUrl'),
@@ -60,4 +61,5 @@ module.exports = (app) => {
   app.use('/api/v1/report', report);
   app.use('/api/v1/user', user);
   app.use('/api/v1/feedback', feedback);
+  app.use('/api/v1/upload', upload);
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -38,7 +38,7 @@ import user from './routes_v1/user';
 import zone from './routes_v1/zone';
 import feedback from './routes_v1/feedback';
 import version from './routes_v1/version';
-import upload from './routes_v1/upload';
+import files from './routes_v1/files';
 
 const corsOptions = {
   // origin: config.get('appUrl'),
@@ -61,5 +61,5 @@ module.exports = (app) => {
   app.use('/api/v1/report', report);
   app.use('/api/v1/user', user);
   app.use('/api/v1/feedback', feedback);
-  app.use('/api/v1/upload', upload);
+  app.use('/api/v1/files', files);
 };

--- a/src/router/routes_v1/plan.js
+++ b/src/router/routes_v1/plan.js
@@ -61,6 +61,12 @@ router.post('/:planId?/status-record', asyncMiddleware(PlanStatusController.stor
 // discard amendment
 router.post('/:planId?/discard-amendment', asyncMiddleware(PlanController.discardAmendment));
 
+// add attachment
+router.post('/:planId?/attachment', asyncMiddleware(PlanController.storeAttachment));
+
+// remove attachment
+router.delete('/:planId?/attachment/:attachmentId?', asyncMiddleware(PlanController.removeAttachment));
+
 //
 // Versions
 //

--- a/src/router/routes_v1/plan.js
+++ b/src/router/routes_v1/plan.js
@@ -64,6 +64,9 @@ router.post('/:planId?/discard-amendment', asyncMiddleware(PlanController.discar
 // add attachment
 router.post('/:planId?/attachment', asyncMiddleware(PlanController.storeAttachment));
 
+// update attachment
+router.put('/:planId?/attachment/:attachmentId?', asyncMiddleware(PlanController.updateAttachment));
+
 // remove attachment
 router.delete('/:planId?/attachment/:attachmentId?', asyncMiddleware(PlanController.removeAttachment));
 

--- a/src/router/routes_v1/upload.js
+++ b/src/router/routes_v1/upload.js
@@ -1,0 +1,57 @@
+import { asyncMiddleware, errorWithCode } from '@bcgov/nodejs-common-utils';
+import * as Minio from 'minio';
+import { Router } from 'express';
+
+const endPoint = process.env.MINIO_ENDPOINT;
+const publicEndPoint = process.env.MINIO_PUBLIC_ENDPOINT;
+const port = process.env.MINIO_PORT;
+const accessKey = process.env.MINIO_ACCESS_KEY;
+const secretKey = process.env.MINIO_SECRET_KEY;
+const bucket = process.env.MINIO_BUCKET;
+
+if (!endPoint) {
+  throw new Error('MINIO_ENDPOINT environment variable not provided');
+}
+
+if (!port) {
+  throw new Error('MINIO_PORT environment variable not provided');
+}
+
+if (!accessKey) {
+  throw new Error('MINIO_ACCESS_KEY environment variable not provided');
+}
+
+if (!secretKey) {
+  throw new Error('MINIO_SECRET_KEY environment variable not provided');
+}
+
+if (!bucket) {
+  throw new Error('MINIO_BUCKET environment variable not provided');
+}
+
+const client = new Minio.Client({
+  endPoint,
+  port: Number(port),
+  useSSL: process.env.NODE_ENV === 'production',
+  accessKey,
+  secretKey,
+  s3ForcePathStyle: true,
+});
+
+const router = new Router();
+
+router.get('/signed-url', asyncMiddleware(async (req, res) => {
+  if (!req.query.name) {
+    throw errorWithCode('You must provide a filename via the `name` parameter', 400);
+  }
+
+  const url = await client.presignedPutObject(bucket, req.query.name);
+
+  res.json({
+    url: publicEndPoint
+      ? url.replace(endPoint, publicEndPoint)
+      : url,
+  });
+}));
+
+export default router;

--- a/test.docker-compose.yml
+++ b/test.docker-compose.yml
@@ -23,6 +23,12 @@ services:
       - POSTGRESQL_HOST=${POSTGRESQL_HOST}
       - NODE_ENV=${ENVIRONMENT}
       - POSTGRESQL_PORT=${POSTGRESQL_PORT}
+      - MINIO_ENDPOINT=minio
+      - MINIO_PUBLIC_ENDPOINT=localhost
+      - MINIO_PORT=9001
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=secretminiokey123
+      - MINIO_BUCKET=myra-test
     networks:
       - local
   db:
@@ -37,6 +43,32 @@ services:
       - POSTGRES_USER=${POSTGRESQL_USER}
       - POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD}
       - POSTGRES_DB=${POSTGRESQL_DATABASE_TEST}
+    networks:
+      - local
+  minio:
+    image: minio/minio
+    ports:
+      - 9001
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: secretminiokey123
+      MINIO_DOMAIN: localhost 
+    command: server /data/minio 
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9001/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    networks:
+      - local
+  minio-nginx:
+    image: nginx
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - 9001:9001
+    depends_on:
+      - minio
     networks:
       - local
 


### PR DESCRIPTION
Adds a `plan_file` table to track files on plans. The files are stored in Minio, and I've added a container to the dev docker-compose environment.

New endpoints are:
* `GET /upload/signed-url?name=<file-name>`: Get a signed URL to upload a file to Minio. `<file-name>` must match the name of the file being uploaded
* `POST /plan/:planId/attachment`: Add a file attachment to a plan. File should already have been uploaded Minio.
* `DELETE /plan/:planId/attachment/attachmentId`: Removes an attachment from a plan. Note that it doesn't actually remove the file from Minio in order for files from previous versions of a plan to still be accessible.

Resolves #217
