### PR TITLE
Make client number primary key again

### DIFF
--- a/__mocks__/fixtures/client_agreement_mock.json
+++ b/__mocks__/fixtures/client_agreement_mock.json
@@ -2,7 +2,7 @@
   {
     "id": 1,
     "agreement_id": "RAN076843",
-    "client_id": 1,
+    "client_id": "09999901",
     "client_type_id": 1,
     "created_at": "2019-03-28T16:35:58.040Z",
     "updated_at": "2019-03-28T16:35:58.040Z"

--- a/__mocks__/fixtures/plan_confirmation_mock.json
+++ b/__mocks__/fixtures/plan_confirmation_mock.json
@@ -1,7 +1,7 @@
 [
   {
     "plan_id": 2,
-    "client_id": 1,
+    "client_id": "09999901",
     "confirmed": true,
     "created_at": "2019-03-28T16:35:58.040Z"
   }

--- a/__mocks__/passport.js
+++ b/__mocks__/passport.js
@@ -50,7 +50,7 @@ const canAccessAgreement = (async (db, agreement) => {
 
 passport.aUser = user;
 passport.aUser.canAccessAgreement = canAccessAgreement.bind(user);
-passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(() => [3, 4, 5]);
+passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(() => [3, 4, 5]);
 passport.global = {};
 passport.setGlobal = (key, value) => {
   passport.global[key] = value;

--- a/__tests__/api_v1/agreement.spec.js
+++ b/__tests__/api_v1/agreement.spec.js
@@ -34,7 +34,7 @@ describe('Test agreement route', () => {
   afterEach(() => {
     delete passport.aUser.isRangeOfficer;
     delete passport.aUser.isAdministrator;
-    delete passport.aUser.getLinkedClientIds;
+    delete passport.aUser.getLinkedClientNumbers;
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isDecisionMaker = () => false;
     passport.aUser.canAccessAgreement.mockClear();
@@ -46,7 +46,7 @@ describe('Test agreement route', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue([67896675]);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue([67896675]);
     await request(app)
       .get('/api/v1/agreement')
       .expect(200).expect((res) => {
@@ -63,7 +63,7 @@ describe('Test agreement route', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => true;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue([67896675]);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue([67896675]);
     await request(app)
       .get('/api/v1/agreement')
       .expect(200).expect((res) => {
@@ -80,7 +80,7 @@ describe('Test agreement route', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => true;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue([67896675]);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue([67896675]);
     await request(app)
       .get('/api/v1/agreement')
       .expect(401).expect((res) => {
@@ -99,7 +99,7 @@ describe('Test agreement route', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue([67896675]);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue([67896675]);
     await request(app)
       .get('/api/v1/agreement')
       .expect(500).expect((res) => {
@@ -119,7 +119,7 @@ describe('Test agreement route search', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue([67896675]);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue([67896675]);
     await request(app)
       .get('/api/v1/agreement/search?term=965&page=1&limit=10')
       .expect(200).expect((res) => {
@@ -161,7 +161,7 @@ describe('Test agreement route search', () => {
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => true;
     passport.aUser.isDecisionMaker = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.id = 1;
     await request(app)
       .get('/api/v1/agreement/search?term=965&page=1&limit=10')
@@ -184,7 +184,7 @@ describe('Test agreement route search without term', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     await request(app)
       .get('/api/v1/agreement/search?page=1&limit=10')
       .expect(200).expect((res) => {
@@ -205,7 +205,7 @@ describe('Test agreement route search without term', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => true;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     await request(app)
       .get('/api/v1/agreement/search?page=1&limit=10')
       .expect(200).expect((res) => {
@@ -226,7 +226,7 @@ describe('Test agreement route search without term', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => true;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue([67896675]);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue([67896675]);
     await request(app)
       .get('/api/v1/agreement/search?page=1&limit=10')
       .expect(200).expect((res) => {
@@ -248,7 +248,7 @@ describe('Test agreement route to get single agreement', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.canAccessAgreement.mockReturnValue(true);
     await request(app)
       .get('/api/v1/agreement/RAN076843')
@@ -266,7 +266,7 @@ describe('Test agreement route to get single agreement', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => true;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     await request(app)
       .get('/api/v1/agreement/RAN076843')
       .expect(200).expect((res) => {
@@ -283,7 +283,7 @@ describe('Test agreement route to get single agreement', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => true;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     await request(app)
       .get('/api/v1/agreement/RAN076843')
       .expect(200).expect((res) => {
@@ -300,7 +300,7 @@ describe('Test agreement route to get single agreement', () => {
     passport.aUser.isAgreementHolder = () => false;
     passport.aUser.isRangeOfficer = () => true;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.canAccessAgreement.mockReturnValue(false);
     passport.aUser.id = 2;
     await request(app)
@@ -323,7 +323,7 @@ describe('Test agreement route update agreement', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.canAccessAgreement.mockReturnValue(true);
     passport.aUser.id = 1;
     const update = {
@@ -349,7 +349,7 @@ describe('Test agreement route update agreement', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.canAccessAgreement.mockReturnValue(true);
     passport.aUser.id = 1;
     const update = {
@@ -374,7 +374,7 @@ describe('Test agreement route update agreement', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.canAccessAgreement.mockReturnValue(true);
     passport.aUser.id = 1;
     await request(app)
@@ -395,7 +395,7 @@ describe('Test agreement route update agreement', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.id = 1;
     await request(app)
       .put('/api/v1/agreement/RAN999999/zone')
@@ -417,7 +417,7 @@ describe('Test agreement route update agreement', () => {
     passport.aUser.isAgreementHolder = () => true;
     passport.aUser.isRangeOfficer = () => false;
     passport.aUser.isAdministrator = () => false;
-    passport.aUser.getLinkedClientIds = jest.fn().mockReturnValue(['00162356']);
+    passport.aUser.getLinkedClientNumbers = jest.fn().mockReturnValue(['00162356']);
     passport.aUser.canAccessAgreement.mockReturnValue(false);
     passport.aUser.id = 1;
     await request(app)

--- a/__tests__/api_v1/plan.spec.js
+++ b/__tests__/api_v1/plan.spec.js
@@ -248,7 +248,7 @@ describe('Test Plan routes', () => {
 
     const confirmation = {
       planId: 1,
-      clientId: 1,
+      clientId: '09999901',
     };
 
     await request(app)

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -502,7 +502,7 @@ const prepareTestSetup = async () => {
       });
 
       const { id } = await User.findOne(db, { username: user.username });
-      await UserClientLink.create(db, { user_id: id, client_id: client.client_number, active: true, type: 'owner' });
+      await UserClientLink.create(db, { user_id: id, client_id: client.clientNumber, active: true, type: 'owner' });
     });
 
     await Promise.all(clientsP);

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -530,7 +530,8 @@ const prepareTestSetup = async () => {
 };
 
 const pruneConfirmations = async () => {
-  await db.raw(`
+  console.log('Pruning confirmations...');
+  const res = await db.raw(`
     WITH extra_confirmations AS (
       SELECT plan_confirmation.id FROM plan_confirmation
       LEFT JOIN plan ON plan.id = plan_confirmation.plan_id
@@ -544,6 +545,7 @@ const pruneConfirmations = async () => {
     DELETE FROM plan_confirmation
     WHERE id IN (SELECT id FROM extra_confirmations)
   `)
+  console.log(`Deleted ${res.rowCount} confirmations`);
 }
 
 const loadFile = name =>
@@ -666,6 +668,7 @@ const main = async () => {
       await pruneConfirmations();
     } else {
       await loadFTADataFromAPI();
+      await pruneConfirmations();
     }
   } catch (err) {
     console.log(`Error importing data, message = ${err.message}`);

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -448,15 +448,19 @@ const updateClient = async data => {
           client_id: clientNumber,
           client_type_id: clientType.id
         });
-        // TODO: Create confirmations
         const plan = await Plan.findOne(db, { agreement_id: agreementId })
         if (plan) {
+          const existingConfirmation = await PlanConfirmation.findOne(db, {
+            plan_id: plan.id, client_id: clientNumber
+          })
+          if (!existingConfirmation) {
           await PlanConfirmation.create(db, {
             plan_id: plan.id,
             confirmed: false,
             client_id: clientNumber,
           })
         }
+      }
       }
      if(agreement && clientAgreement && clientType) // update if different
         {

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -530,8 +530,12 @@ const pruneConfirmations = async () => {
     WITH extra_confirmations AS (
       SELECT plan_confirmation.id FROM plan_confirmation
       LEFT JOIN plan ON plan.id = plan_confirmation.plan_id
-      LEFT JOIN client_agreement ON client_agreement.agreement_id = plan.agreement_id
-      WHERE client_agreement.client_id != plan_confirmation.client_id
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM client_agreement
+        WHERE agreement_id = plan.agreement_id
+          AND client_id = plan_confirmation.client_id
+      )
     )
     DELETE FROM plan_confirmation
     WHERE id IN (SELECT id FROM extra_confirmations)

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -406,16 +406,15 @@ const updateClient = async data => {
     try {
       let client = await Client.findOne(db, {
         client_number: clientNumber,
-        location_code: clientLocationCode
       });
 
       if (client) {
         await Client.update(
           db,
-          { id: client.id },
+          { client_number: clientNumber },
           {
             name: clientName || "Unknown Name",
-            locationCode: clientLocationCode,
+            locationCodes: Array.from(new Set(client.locationCodes.concat(clientLocationCode))),
             startDate: licenseeStartDate ? parseDate(licenseeStartDate) : null
           }
         );
@@ -424,7 +423,7 @@ const updateClient = async data => {
         client = await Client.create(db, {
           clientNumber: clientNumber,
           name: clientName || "Unknown Name",
-          locationCode: clientLocationCode,
+          locationCodes: [clientLocationCode],
           startDate: licenseeStartDate ? parseDate(licenseeStartDate) : null
         });
         created += 1;
@@ -432,20 +431,19 @@ const updateClient = async data => {
       const agreement = await Agreement.findById(db, agreementId);
       const clientAgreement = await ClientAgreement.findOne(db, {
         agreement_id: agreementId,
-        client_id: client.id
+        client_id: clientNumber
       });
-    if(clientAgreement && (typeof clientType === 'undefined')) // clean up the stale ones here
-    {
+      if(clientAgreement && (typeof clientType === 'undefined')) { // clean up the stale ones here
         await ClientAgreement.remove(db, {
           agreement_id: agreementId,
-          client_id: client.id,
+          client_id: clientNumber,
         });
         deleted += 1;
-    }
-      if (agreement && !clientAgreement && clientType) { //only create if they are A or B
+      }
+      if (agreement && !clientAgreement && clientType) { // only create if they are A or B
         await ClientAgreement.create(db, {
           agreement_id: agreementId,
-          client_id: client.id,
+          client_id: clientNumber,
           client_type_id: clientType.id
         });
       }
@@ -504,7 +502,7 @@ const prepareTestSetup = async () => {
       });
 
       const { id } = await User.findOne(db, { username: user.username });
-      await UserClientLink.create(db, { user_id: id, client_id: client.id, active: true, type: 'owner' });
+      await UserClientLink.create(db, { user_id: id, client_id: client.client_number, active: true, type: 'owner' });
     });
 
     await Promise.all(clientsP);

--- a/src/libs/db2/migrations/20200728091522_make-client_number-unique.js
+++ b/src/libs/db2/migrations/20200728091522_make-client_number-unique.js
@@ -1,0 +1,176 @@
+exports.up = async (knex) => {
+  // Custom aggregate function to concat arrays
+  await knex.raw(`
+    DROP AGGREGATE IF EXISTS array_agg_mult (anyarray);
+
+    CREATE AGGREGATE array_cat_agg (
+      anyarray) (
+      SFUNC = array_cat,
+      STYPE = anyarray
+    );
+  `);
+  // Get clients
+  const { rows: clients } = await knex.raw(`
+    SELECT
+      ref_client.client_number,
+      array_agg(ref_client.id) client_ids,
+      array_cat_agg (pc.ids) AS plan_confirmation_ids,
+      array_cat_agg (ca.ids) AS client_agreement_ids,
+      array_cat_agg (link.ids) AS link_ids
+    FROM
+      ref_client
+      LEFT JOIN (
+        SELECT
+          client_id,
+          ARRAY_AGG(plan_confirmation.id) AS ids
+        FROM
+          plan_confirmation
+        GROUP BY
+          1) pc ON pc.client_id = ref_client.id
+      LEFT JOIN (
+        SELECT
+          client_id,
+          ARRAY_AGG(client_agreement.id) AS ids
+        FROM
+          client_agreement
+        GROUP BY
+          1) ca ON ca.client_id = ref_client.id
+      LEFT JOIN (
+        SELECT
+          client_id,
+          ARRAY_AGG(user_client_link.id) AS ids
+        FROM
+          user_client_link
+        GROUP BY
+          1) link ON link.client_id = ref_client.id
+    GROUP BY
+      client_number;
+  `);
+
+
+  // Change type of client_id columns
+
+  await knex.raw(`
+    ALTER TABLE client_agreement 
+      DROP COLUMN client_id,
+      ADD COLUMN client_id VARCHAR
+  `);
+
+  await knex.raw(`
+    ALTER TABLE plan_confirmation
+      DROP COLUMN client_id,
+      ADD COLUMN client_id VARCHAR
+  `);
+
+  await knex.raw(`
+    ALTER TABLE user_client_link
+      DROP COLUMN client_id,
+      ADD COLUMN client_id VARCHAR
+  `);
+
+  // Update values for `client_id` to the client number
+  const updatedClientsP = clients.map(async (client) => {
+    const {
+      plan_confirmation_ids: pcIds,
+      client_agreement_ids: caIds,
+      link_ids: linkIds,
+    } = client;
+
+    if (pcIds) {
+      await knex.raw(`
+        UPDATE plan_confirmation
+        SET client_id = ? 
+        WHERE id = ANY (?);
+      `, [client.client_number, pcIds]);
+    }
+    if (caIds) {
+      await knex.raw(`
+        UPDATE client_agreement
+        SET client_id = ? 
+        WHERE id = ANY (?);
+      `, [client.client_number, caIds]);
+    }
+    if (linkIds) {
+      await knex.raw(`
+        UPDATE user_client_link
+        SET client_id = ? 
+        WHERE id = ANY (?);
+      `, [client.client_number, linkIds]);
+    }
+  });
+
+  await updatedClientsP;
+
+  await knex.raw(`
+    alter table ref_client
+      add column location_codes varchar(2)[];
+  `);
+
+  // Populate location_codes with values from every row with the same client_number
+  await knex.raw(`
+    WITH subquery AS (
+      SELECT
+        id,
+        array(
+          SELECT location_code
+          FROM ref_client
+          WHERE ref_client.client_number = rc.client_number
+        ) as location_codes
+      FROM ref_client rc
+    )
+    UPDATE ref_client
+    SET location_codes = subquery.location_codes
+    FROM subquery
+    WHERE ref_client.id = subquery.id;
+  `);
+
+  // Remove duplicates
+  await knex.raw(`
+    DELETE FROM
+      ref_client a
+          USING ref_client b
+    WHERE
+      a.id < b.id
+      AND a.client_number = b.client_number;
+  `);
+
+  // Change primary key of ref_client to `client_number`
+  await knex.raw(`
+    ALTER TABLE ref_client 
+      DROP CONSTRAINT ref_client_pkey CASCADE,
+      ADD PRIMARY KEY (client_number);
+  `);
+
+  // Recreate foreign keys
+  await knex.raw(`
+    ALTER TABLE client_agreement
+      ADD FOREIGN KEY (client_id) REFERENCES ref_client(client_number);
+    ALTER TABLE plan_confirmation
+      ADD FOREIGN KEY (client_id) REFERENCES ref_client(client_number);
+    ALTER TABLE user_client_link
+      ADD FOREIGN KEY (client_id) REFERENCES ref_client(client_number);
+  `);
+
+  // Remove old columns
+  await knex.raw(`
+    ALTER TABLE ref_client
+      DROP COLUMN id,
+      DROP COLUMN location_code;
+  `);
+
+  // Cleanup
+
+  await knex.raw(`
+    DROP AGGREGATE IF EXISTS array_agg_mult (anyarray);
+  `);
+
+  await knex.raw(`
+    DROP FUNCTION IF EXISTS update_plan_conf_to_reflect_client_agreement() CASCADE;
+  `);
+
+  await knex.raw(`
+    DROP TRIGGER IF EXISTS update_plan_conf_with_old_client_agreement on client_agreement;
+  `);
+};
+
+exports.down = async () => {};

--- a/src/libs/db2/migrations/20200805103236_remove-duplicates-from-client_number-change.js
+++ b/src/libs/db2/migrations/20200805103236_remove-duplicates-from-client_number-change.js
@@ -1,0 +1,31 @@
+exports.up = async (knex) => {
+  await knex.raw(`
+    DELETE FROM
+      client_agreement a
+          USING client_agreement b
+    WHERE
+      a.id < b.id
+      AND a.agreement_id = b.agreement_id
+      AND a.client_id = b.client_id;
+  `);
+  await knex.raw(`
+    DELETE FROM
+      plan_confirmation a
+          USING plan_confirmation b
+    WHERE
+      a.id < b.id
+      AND a.plan_id = b.plan_id
+      AND a.client_id = b.client_id;
+  `);
+  await knex.raw(`
+    DELETE FROM
+      user_client_link a
+          USING user_client_link b
+    WHERE
+      a.id < b.id
+      AND a.user_id = b.user_id
+      AND a.client_id = b.client_id;
+  `);
+};
+
+exports.down = async () => {};

--- a/src/libs/db2/model/__mocks__/client.js
+++ b/src/libs/db2/model/__mocks__/client.js
@@ -6,20 +6,20 @@ export default class Client extends Model {
   static async find(db, where) {
     assert(db);
     assert(where);
-    assert(where.id);
+    assert(where.client_number);
 
     return {
-      clientId: where.id,
+      clientNumber: where.client_number,
     };
   }
 
   static async findOne(db, where) {
     assert(db);
     assert(where);
-    assert(where.id);
+    assert(where.client_number);
 
     return {
-      clientId: where.id,
+      clientNumber: where.client_number,
     };
   }
 

--- a/src/libs/db2/model/__mocks__/user.js
+++ b/src/libs/db2/model/__mocks__/user.js
@@ -30,7 +30,7 @@ export default class User extends Model {
     }
   }
 
-  getLinkedClientIds(db) {
+  getLinkedClientNumbers(db) {
     assert(db);
 
     return [1, 2, 3];

--- a/src/libs/db2/model/agreement.js
+++ b/src/libs/db2/model/agreement.js
@@ -151,7 +151,7 @@ export default class Agreement extends Model {
         .leftJoin('plan', { 'agreement.forest_file_id': 'plan.agreement_id' })
         .leftJoin('user_account as plan_creator', { 'plan.creator_id': 'plan_creator.id' })
         .leftJoin('client_agreement', { 'agreement.forest_file_id': 'client_agreement.agreement_id', 'client_agreement.client_type_id': 1 })
-        .leftJoin('ref_client as agreement_holder', { 'agreement_holder.id': 'client_agreement.client_id' })
+        .leftJoin('ref_client as agreement_holder', { 'agreement_holder.client_number': 'client_agreement.client_id' })
         .leftJoin('ref_plan_status as plan_status', { 'plan.status_id': 'plan_status.id' })
         .leftJoin('ref_agreement_type', { 'agreement.agreement_type_id': 'ref_agreement_type.id' })
         .leftJoin('ref_agreement_exemption_status', { 'agreement.agreement_exemption_status_id': 'ref_agreement_exemption_status.id' })

--- a/src/libs/db2/model/agreement.js
+++ b/src/libs/db2/model/agreement.js
@@ -314,9 +314,8 @@ export default class Agreement extends Model {
 
     const clients = this.clients.map((client) => {
       const aClient = {
-        id: client.id,
-        clientNumber: client.clientNumber,
-        locationCode: client.locationCode,
+        id: client.clientNumber,
+        locationCodes: client.locationCodes,
         name: client.name,
         clientTypeCode: client.clientType.code,
         startDate: client.licenseeStartDate,

--- a/src/libs/db2/model/client.js
+++ b/src/libs/db2/model/client.js
@@ -41,13 +41,13 @@ export default class Client extends Model {
   }
 
   // To match previous Agreement (sequelize) schema.
-  // get id() {
-  //   return this.clientNumber;
-  // }
+  get id() {
+    return this.clientNumber;
+  }
 
   static get fields() {
     // primary key *must* be first!
-    return ['id', 'client_number', 'location_code', 'name', 'licensee_start_date', 'licensee_end_date']
+    return ['client_number', 'location_codes', 'name', 'licensee_start_date', 'licensee_end_date']
       .map(field => `${this.table}.${field}`);
   }
 
@@ -68,7 +68,7 @@ export default class Client extends Model {
     const results = await db
       .select(myFields)
       .from(Client.table)
-      .join('client_agreement', { 'client_agreement.client_id': 'ref_client.id' })
+      .join('client_agreement', { 'client_agreement.client_id': 'ref_client.client_number' })
       .join('ref_client_type', { 'client_agreement.client_type_id': 'ref_client_type.id' })
       .where({ 'client_agreement.agreement_id': agreement.forestFileId });
 

--- a/src/libs/db2/model/planconfirmation.js
+++ b/src/libs/db2/model/planconfirmation.js
@@ -48,7 +48,7 @@ export default class PlanConfirmation extends Model {
     const promises = agreement.clients.map(client => (
       PlanConfirmation.create(db, {
         plan_id: planId,
-        client_id: client.id,
+        client_id: client.clientNumber,
         confirmed: false,
       })
     ));

--- a/src/libs/db2/model/user.js
+++ b/src/libs/db2/model/user.js
@@ -94,7 +94,7 @@ export default class User extends Model {
           `
           SELECT user_account.*, ref_client.client_number FROM user_account
           LEFT JOIN user_client_link ON user_client_link.user_id = user_account.id
-          LEFT JOIN ref_client ON ref_client.id = user_client_link.client_id
+          LEFT JOIN ref_client ON ref_client.client_number = user_client_link.client_id
           WHERE user_account.id = ?;
         `,
           [id]
@@ -144,7 +144,7 @@ export default class User extends Model {
         `
         SELECT DISTINCT ON (user_account.id) user_id, user_account.*, ref_client.client_number FROM user_account
         LEFT JOIN user_client_link ON user_client_link.user_id = user_account.id
-        LEFT JOIN ref_client ON ref_client.id = user_client_link.client_id
+        LEFT JOIN ref_client ON ref_client.client_number = user_client_link.client_id
         WHERE user_account.id = ANY (?) ORDER BY user_account.id, ?;
       `,
         [userIds, order],
@@ -156,7 +156,7 @@ export default class User extends Model {
     }
   }
 
-  async getLinkedClientIds(db) {
+  async getLinkedClientNumbers(db) {
     const clientLinks = await UserClientLink.find(db, {
       user_id: this.id,
       active: true,
@@ -195,7 +195,7 @@ User.prototype.canAccessAgreement = async function(db, agreement) {
   }
 
   if (this.isAgreementHolder()) {
-    const clientIds = await this.getLinkedClientIds(db);
+    const clientIds = await this.getLinkedClientNumbers(db);
 
     const [result] = await db
       .table('client_agreement')

--- a/src/router/controllers_v1/UserController.js
+++ b/src/router/controllers_v1/UserController.js
@@ -53,9 +53,9 @@ export class UserController {
         await User.update(db, { id: user.id }, { pia_seen: true });
       }
 
-      const clientIds = await user.getLinkedClientIds(db);
+      const clientIds = await user.getLinkedClientNumbers(db);
 
-      const clients = await Client.find(db, { id: clientIds });
+      const clients = await Client.find(db, { client_number: clientIds });
 
       res.status(200).json({ ...user, clients }).end();
     } catch (error) {
@@ -102,7 +102,7 @@ export class UserController {
       ['clientId'], 'body', req,
     );
 
-    const client = await Client.findOne(db, { id: clientId });
+    const client = await Client.findOne(db, { client_number: clientId });
     if (!client) {
       throw errorWithCode('Client does not exist', 400);
     }
@@ -124,7 +124,7 @@ export class UserController {
 
     const userToLink = new User({ id: userId });
 
-    const currentLinkedClientIds = await userToLink.getLinkedClientIds(db);
+    const currentLinkedClientIds = await userToLink.getLinkedClientNumbers(db);
 
     const currentLinkedAgreements = await ClientAgreement.find(db, {
       client_id: currentLinkedClientIds,
@@ -159,18 +159,18 @@ export class UserController {
 
   static async removeClientLink(req, res) {
     const { user, params } = req;
-    const { clientId, userId } = params;
+    const { clientNumber, userId } = params;
 
     if (user && user.isAgreementHolder()) {
       throw errorWithCode('Unauthorized', 403);
     }
 
     checkRequiredFields(
-      ['clientId', 'userId'], 'params', req,
+      ['clientNumber', 'userId'], 'params', req,
     );
 
     const result = await UserClientLink.remove(db, {
-      client_id: clientId,
+      client_id: clientNumber,
       user_id: userId,
     });
 
@@ -191,9 +191,9 @@ export class UserController {
 
     const userToFind = await User.findById(db, userId);
 
-    const clientIds = await userToFind.getLinkedClientIds(db);
+    const clientIds = await userToFind.getLinkedClientNumbers(db);
 
-    const clients = await Client.find(db, { id: clientIds });
+    const clients = await Client.find(db, { client_number: clientIds });
 
     res.status(200).json({ ...userToFind, clients }).end();
   }

--- a/src/router/routes_v1/agreement.js
+++ b/src/router/routes_v1/agreement.js
@@ -44,7 +44,7 @@ const {
 const allowableIDsForUser = async (user, agreementIDs, selectedZoneIds = []) => {
   let okIDs = [];
   if (user.isAgreementHolder()) {
-    const clientIds = await user.getLinkedClientIds(db);
+    const clientIds = await user.getLinkedClientNumbers(db);
 
     const clientAgreements = await ClientAgreement.find(db, { client_id: clientIds });
     const agentAgreements = await ClientAgreement.find(db, { agent_id: user.id });
@@ -109,7 +109,7 @@ const getAgreeementsForAH = async ({
   page = undefined, limit = undefined, orderBy = 'agreement.forest_file_id', order = 'asc',
   user, latestPlan = true, sendFullPlan = false, staffDraft = false,
 }) => {
-  const clientIds = await user.getLinkedClientIds(db);
+  const clientIds = await user.getLinkedClientNumbers(db);
 
   const clientAgreements = await ClientAgreement.find(db, { client_id: clientIds });
   const agentClientAgreements = await ClientAgreement.find(db, { agent_id: user.id });

--- a/src/router/routes_v1/client.js
+++ b/src/router/routes_v1/client.js
@@ -95,7 +95,7 @@ router.get('/:clientId', asyncMiddleware(async (req, res) => {
       throw errorWithCode('Unauthorized', 401);
     }
 
-    const results = await Client.find(db, { id: clientId });
+    const results = await Client.find(db, { client_number: clientId });
     if (results.length === 0) {
       res.status(404).json({ error: 'Not found' }).end();
     }

--- a/src/router/routes_v1/user.js
+++ b/src/router/routes_v1/user.js
@@ -42,6 +42,6 @@ router.get('/:userId', asyncMiddleware(UserController.show));
 
 // Assign a client id to user
 router.post('/:userId?/client', asyncMiddleware(UserController.addClientLink));
-router.delete('/:userId?/client/:clientId?', asyncMiddleware(UserController.removeClientLink));
+router.delete('/:userId?/client/:clientNumber?', asyncMiddleware(UserController.removeClientLink));
 
 module.exports = router;


### PR DESCRIPTION
Switches the primary key of `ref_client` from `id` to `client_number`, updating foreign keys as appropriate. Also merges all rows for different location codes and stores those location codes in a new array column `location_codes`.

The import job has been modified to create false `plan_confirmation` records for new `client_agreement`s, and prune confirmations after `client_agreement`s are completely removed.