### PR TITLE
DB roles migration from SSO and read only role

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,7 @@ export const SSO_ROLE_MAP = {
   RANGE_OFFICER: 'myra_range_officer',
   AGREEMENT_HOLDER: 'myra_client',
   DECISION_MAKER: 'myra_decision_maker',
+  READ_ONLY: 'myra_read_only'
 };
 
 export const PLAN_STATUS = {

--- a/src/libs/authmware.js
+++ b/src/libs/authmware.js
@@ -204,6 +204,7 @@ export default async function initPassport(app) {
           }, {
             roleId: roleIdToAdd, //Defaults to client
           });
+          user.roleId = roleIdToAdd;
 
           permissions = await UserPermissions.getRolePermissions(db, roleIdToAdd);
         }

--- a/src/libs/authmware.js
+++ b/src/libs/authmware.js
@@ -29,6 +29,7 @@ import jwksRsa from 'jwks-rsa';
 import config from '../config';
 import DataManager from './db2';
 import { SSO_ROLE_MAP } from '../constants';
+import UserPermissions from './db2/model/userPermissions';
 
 const dm = new DataManager(config);
 const { db, User } = dm;
@@ -174,6 +175,19 @@ export default async function initPassport(app) {
         } else {
           user.roles = basicRoles;
         }
+
+        //Add new permissions based on roles
+        let permissions = [];
+        if (user.roleId) {
+          //Get permissions
+          permissions = await UserPermissions.getRolePermissions(db, user);
+        } else {
+          //set role id based on jwt
+        }
+
+        //Set permissions
+        user.permissions = permissions;
+
 
         if (!user.isActive()) {
           return done(

--- a/src/libs/db2/index.js
+++ b/src/libs/db2/index.js
@@ -65,6 +65,7 @@ import UserClientLink from './model/userclientlink';
 import PlanFile from './model/PlanFile';
 import EmailTemplate from './model/emailtemplate';
 import PlanExtensionRequests from './model/planextensionrequests';
+import UserPermissions from './model/userPermissions';
 
 export const connection = knex({
   client: 'pg',
@@ -116,6 +117,7 @@ export default class DataManager {
     this.PlanExtensionRequests = PlanExtensionRequests;
     this.Pasture = Pasture;
     this.User = User;
+    this.Role = UserPermissions;
     this.Usage = Usage;
     this.Zone = Zone;
     this.AmendmentType = AmendmentType;

--- a/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
+++ b/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
@@ -56,6 +56,7 @@ exports.up = async (knex) => {
     (1, 9),
     (1, 10),
     (1, 11),
+    (2, 6),
     (2, 10),
     (3, 2),
     (3, 5),
@@ -72,8 +73,8 @@ exports.up = async (knex) => {
 };
 
 exports.down = async (knex) => {
-  await knex.raw("ALTER TABLE user_account DROP COLUMN role_id");
-  await knex.raw("DROP TABLE role_permissions");
-  await knex.raw("DROP TABLE roles");
-  await knex.raw("DROP TABLE permissions");
+  await knex.raw('ALTER TABLE user_account DROP COLUMN role_id');
+  await knex.raw('DROP TABLE role_permissions');
+  await knex.raw('DROP TABLE roles');
+  await knex.raw('DROP TABLE permissions');
 };

--- a/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
+++ b/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
@@ -31,7 +31,8 @@ exports.up = async (knex) => {
     ('Write in my RUPS as client'),
     ('Manage clients as staff'),
     ('Manage email templates as staff'),
-    ('Decision maker as staff');
+    ('Decision maker as staff'),
+    ('Assign users a role');
   `);
   await knex.raw(`
   CREATE TABLE IF NOT EXISTS role_permissions (
@@ -54,6 +55,7 @@ exports.up = async (knex) => {
     (1, 8),
     (1, 9),
     (1, 10),
+    (1, 11),
     (2, 10),
     (3, 2),
     (3, 5),

--- a/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
+++ b/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
@@ -14,9 +14,9 @@ exports.up = async (knex) => {
   INSERT INTO roles (description)
   VALUES
     ('Admin'),
-    ('Staff Range Plan Editor'),
+    ('Staff Decision Maker'),
     ('Staff Agrologist'),
-    ('Client Agreement Holder'),
+    ('Range Agreement Holder'),
     ('External Auditor');
   `);
   await knex.raw(`
@@ -49,8 +49,7 @@ exports.up = async (knex) => {
   );`);
   await knex.raw(`
   INSERT INTO role_permissions (role_id, permission_id)
-  VALUES
-    (1, 1),
+  VALUES (1, 1),
     (1, 4),
     (1, 8),
     (1, 9),
@@ -58,7 +57,6 @@ exports.up = async (knex) => {
     (2, 10),
     (3, 2),
     (3, 5),
-    (4, 2),
     (4, 7),
     (5, 1);
   `);

--- a/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
+++ b/src/libs/db2/migrations/20240227121082_roles_and_permissions.js
@@ -1,0 +1,79 @@
+exports.up = async (knex) => {
+  await knex.raw(`
+  CREATE TABLE IF NOT EXISTS roles (
+    id SERIAL PRIMARY KEY,
+    description VARCHAR(255) UNIQUE NOT NULL
+  );`);
+  await knex.raw(`
+  CREATE TABLE IF NOT EXISTS permissions (
+    id SERIAL PRIMARY KEY,
+    description VARCHAR(255) UNIQUE NOT NULL
+  );`);
+
+  await knex.raw(`
+  INSERT INTO roles (description)
+  VALUES
+    ('Admin'),
+    ('Staff Range Plan Editor'),
+    ('Staff Agrologist'),
+    ('Client Agreement Holder'),
+    ('External Auditor');
+  `);
+  await knex.raw(`
+  INSERT INTO permissions (description)
+  VALUES
+    ('Read everything as staff'),
+    ('Read in my zones as staff'),
+    ('Read in my districts as staff'),
+    ('Write everything as staff'),
+    ('Write in my zones as staff'),
+    ('Write in my districts as staff'),
+    ('Write in my RUPS as client'),
+    ('Manage clients as staff'),
+    ('Manage email templates as staff'),
+    ('Decision maker as staff');
+  `);
+  await knex.raw(`
+  CREATE TABLE IF NOT EXISTS role_permissions (
+    id SERIAL PRIMARY KEY,
+    role_id INT,
+    permission_id INT,
+    CONSTRAINT role_id
+      FOREIGN KEY(role_id)
+        REFERENCES roles(id)
+        ON DELETE SET NULL,
+    CONSTRAINT permission_id
+      FOREIGN KEY(role_id)
+        REFERENCES permissions(id)
+        ON DELETE SET NULL
+  );`);
+  await knex.raw(`
+  INSERT INTO role_permissions (role_id, permission_id)
+  VALUES
+    (1, 1),
+    (1, 4),
+    (1, 8),
+    (1, 9),
+    (1, 10),
+    (2, 10),
+    (3, 2),
+    (3, 5),
+    (4, 2),
+    (4, 7),
+    (5, 1);
+  `);
+  await knex.raw(`
+  ALTER TABLE user_account
+  ADD COLUMN role_id INT;
+  ALTER TABLE user_account
+  ADD CONSTRAINT role_foreign_key
+    FOREIGN KEY (role_id) REFERENCES roles(id);
+  `);
+};
+
+exports.down = async (knex) => {
+  await knex.raw("ALTER TABLE user_account DROP COLUMN role_id");
+  await knex.raw("DROP TABLE role_permissions");
+  await knex.raw("DROP TABLE roles");
+  await knex.raw("DROP TABLE permissions");
+};

--- a/src/libs/db2/model/user.js
+++ b/src/libs/db2/model/user.js
@@ -20,8 +20,8 @@
 
 'use strict';
 
-import { SSO_ROLE_MAP } from '../../../constants';
-import Model from './model';
+import { SSO_ROLE_MAP } from "../../../constants";
+import Model from "./model";
 import UserClientLink from './userclientlink';
 
 export default class User extends Model {
@@ -44,23 +44,25 @@ export default class User extends Model {
       clientNumber: row.client_number,
       phoneNumber: row.phone_number,
       ssoId: row.sso_id,
+      roleId: row.role_id
     };
   }
 
   static get fields() {
     // primary key *must* be first!
     return [
-      'id',
-      'username',
-      'given_name',
-      'family_name',
-      'email',
-      'phone_number',
-      'active',
-      'pia_seen',
-      'last_login_at',
-      'sso_id',
-    ].map((field) => `${this.table}.${field}`);
+      "id",
+      "username",
+      "given_name",
+      "family_name",
+      "email",
+      "phone_number",
+      "active",
+      "pia_seen",
+      "last_login_at",
+      "sso_id",
+      "role_id"
+    ].map(field => `${this.table}.${field}`);
   }
 
   static get table() {
@@ -248,7 +250,11 @@ User.prototype.isAdministrator = function () {
   return this.roles && this.roles.includes(SSO_ROLE_MAP.ADMINISTRATOR);
 };
 
-User.prototype.isAgreementHolder = function () {
+User.prototype.isReadOnly = function() {
+  return this.roles && this.roles.includes(SSO_ROLE_MAP.READ_ONLY);
+};
+
+User.prototype.isAgreementHolder = function() {
   return this.roles && this.roles.includes(SSO_ROLE_MAP.AGREEMENT_HOLDER);
 };
 

--- a/src/libs/db2/model/user.js
+++ b/src/libs/db2/model/user.js
@@ -197,7 +197,7 @@ User.prototype.canAccessAgreement = async function (db, agreement) {
     return false;
   }
 
-  if (this.isAdministrator()) {
+  if (this.isAdministrator() || this.canReadAll()) {
     return true;
   }
 
@@ -247,21 +247,33 @@ User.prototype.canAccessAgreement = async function (db, agreement) {
 };
 
 User.prototype.isAdministrator = function () {
-  return this.roles && this.roles.includes(SSO_ROLE_MAP.ADMINISTRATOR);
-};
-
-User.prototype.isReadOnly = function() {
-  return this.roles && this.roles.includes(SSO_ROLE_MAP.READ_ONLY);
-};
-
-User.prototype.isAgreementHolder = function() {
-  return this.roles && this.roles.includes(SSO_ROLE_MAP.AGREEMENT_HOLDER);
-};
-
-User.prototype.isRangeOfficer = function () {
-  return this.roles && this.roles.includes(SSO_ROLE_MAP.RANGE_OFFICER);
+  return this.roleId && this.roleId === 1;
 };
 
 User.prototype.isDecisionMaker = function () {
-  return this.roles && this.roles.includes(SSO_ROLE_MAP.DECISION_MAKER);
+  return this.roleId && this.roleId === 2;
 };
+
+User.prototype.isRangeOfficer = function () {
+  return this.roleId && this.roleId === 3;
+};
+
+User.prototype.isAgreementHolder = function() {
+  return this.roleId && this.roleId === 4;
+};
+
+User.prototype.isReadOnly = function() {
+  return this.roleId && this.roleId === 5;
+};
+
+User.prototype.canReadAll = function() {
+  return this.permissions && this.permissions.find(p => p.id === 1);
+}
+
+User.prototype.canReadZone = function() {
+  return this.permissions && this.permissions.find(p => p.id === 2);
+}
+
+User.prototype.canReadDistrict = function() {
+  return this.permissions && this.permissions.find(p => p.id === 3);
+}

--- a/src/libs/db2/model/userPermissions.js
+++ b/src/libs/db2/model/userPermissions.js
@@ -1,0 +1,41 @@
+import Model from './model';
+
+export default class UserPermissions extends Model {
+  constructor(data, db = undefined) {
+    const obj = {};
+    Object.keys(data).forEach((key) => {
+      if (UserPermissions.fields.indexOf(`${UserPermissions.table}.${key}`) > -1) {
+        obj[key] = data[key];
+      }
+    });
+
+    super(obj, db);
+  }
+
+  static get fields() {
+    // primary key *must* be first!
+    return [
+      'id', 'role_id', 'permission_id'
+    ].map(f => `${UserPermissions.table}.${f}`);
+  }
+
+  static get table() {
+    return 'role_permissions';
+  }
+
+  static async getRolePermissions(db, user) {
+    const [...result] = await db
+    .table('role_permissions')
+    .join('permissions', { 'permissions.id': 'role_permissions.permission_id'})
+    .where({
+      'role_permissions.role_id': user.roleId,
+    });
+    
+    return result.map(permission => {
+      return {
+        id: permission.permission_id,
+        description: permission.description
+      }
+    });
+  }
+}

--- a/src/libs/db2/model/userPermissions.js
+++ b/src/libs/db2/model/userPermissions.js
@@ -38,4 +38,16 @@ export default class UserPermissions extends Model {
       }
     });
   }
+
+  static async getRoles(db) {
+    const [...result] = await db
+    .table('roles');
+    
+    return result.map(role => {
+      return {
+        id: role.id,
+        description: role.description
+      }
+    });
+  }
 }

--- a/src/libs/db2/model/userPermissions.js
+++ b/src/libs/db2/model/userPermissions.js
@@ -23,12 +23,12 @@ export default class UserPermissions extends Model {
     return 'role_permissions';
   }
 
-  static async getRolePermissions(db, user) {
+  static async getRolePermissions(db, roleId) {
     const [...result] = await db
     .table('role_permissions')
     .join('permissions', { 'permissions.id': 'role_permissions.permission_id'})
     .where({
-      'role_permissions.role_id': user.roleId,
+      'role_permissions.role_id': roleId,
     });
     
     return result.map(permission => {

--- a/src/router/controllers_v1/PlanController.js
+++ b/src/router/controllers_v1/PlanController.js
@@ -70,7 +70,8 @@ export default class PlanController {
       const isStaff =
         user.isAdministrator() ||
         user.isRangeOfficer() ||
-        user.isDecisionMaker();
+        user.isDecisionMaker() ||
+        user.canReadAll();
 
       const [privacyVersionRaw] = await PlanSnapshot.findSummary(db, {
         plan_id: planId,

--- a/src/router/controllers_v1/RoleController.js
+++ b/src/router/controllers_v1/RoleController.js
@@ -1,0 +1,28 @@
+import DataManager from '../../libs/db2';
+import config from '../../config';
+
+const dm = new DataManager(config);
+const {
+  db,
+  Role,
+} = dm;
+
+export class RoleController {
+  // Fetching all roles
+  static async allRoles(req, res) {
+    try {
+      const roles = await Role.getRoles(db);
+
+      res.status(200).json(roles).end();
+      return;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  
+}
+
+const roleController = new RoleController();
+
+export default roleController;

--- a/src/router/controllers_v1/UserController.js
+++ b/src/router/controllers_v1/UserController.js
@@ -91,7 +91,7 @@ export class UserController {
   }
 
   static async mergeAccounts(req, res) {
-    const { user, params, body } = req;
+    const { params, body } = req;
     const { userId } = params;
     const sourceAccountIds = body.accountIds;
     checkRequiredFields(['userId'], 'params', req);
@@ -136,7 +136,7 @@ export class UserController {
   }
 
   static async addClientLink(req, res) {
-    const { user, params, body } = req;
+    const { params, body } = req;
     const { userId } = params;
     const { clientId } = body;
 
@@ -224,7 +224,7 @@ export class UserController {
   }
 
   static async removeClientLink(req, res) {
-    const { user, params } = req;
+    const { params } = req;
     const { clientNumber, userId } = params;
 
     checkRequiredFields(['clientNumber', 'userId'], 'params', req);
@@ -241,8 +241,28 @@ export class UserController {
     res.status(200).json(result).end();
   }
 
+  static async assignUserRole(req, res) {
+    try {
+      const { body, params } = req;
+      const { userId: userId } = params;
+      const roleId = body.roleId;
+
+      const updated = await User.update(
+        db,
+        { id: userId },
+        {
+          roleId,
+        },
+      );
+
+      res.status(200).json(updated).end();
+    } catch (error) {
+      throw error;
+    }
+  }
+
   static async show(req, res) {
-    const { user, params } = req;
+    const { params } = req;
     const { userId } = params;
 
     const userToFind = await User.findById(db, userId);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -36,6 +36,7 @@ import files from './routes_v1/files';
 import plan from './routes_v1/plan';
 import reference from './routes_v1/reference';
 import user from './routes_v1/user';
+import roles from './routes_v1/roles';
 import version from './routes_v1/version';
 import zone from './routes_v1/zone';
 import emailTemplate from './routes_v1/emailTemplate';
@@ -59,6 +60,7 @@ module.exports = (app) => {
   app.use('/api/v1/reference', reference);
   app.use('/api/v1/zone', zone);
   app.use('/api/v1/user', user);
+  app.use('/api/v1/roles', roles);
   app.use('/api/v1/feedback', feedback);
   app.use('/api/v1/files', files);
   app.use('/api/v1/emailTemplate', emailTemplate);

--- a/src/router/routes_v1/agreement.js
+++ b/src/router/routes_v1/agreement.js
@@ -96,15 +96,13 @@ const agreementCountForUser = async (user) => {
   if (user.isAgreementHolder()) {
     const ids = await Agreement.agreementsForClientId(db, user.clientId);
     count = ids.length;
-  } else if (user.isRangeOfficer()) {
+  } else if (user.isRangeOfficer() || user.isAdministrator() || user.canReadAll()) {
     const zones = await Zone.findWithDistrictUser(db, {
       'ref_zone.user_id': user.id,
     });
     const zids = zones.map((zone) => zone.id);
     const ids = await Agreement.find(db, { zone_id: zids });
     count = ids.length;
-  } else if (user.isAdministrator() || user.canReadAll()) {
-    count = await Agreement.count(db);
   } else if (user.isDecisionMaker()) {
     const districts = await District.find(db, { user_id: user.id });
     const zones = await Zone.find(db, {
@@ -115,7 +113,7 @@ const agreementCountForUser = async (user) => {
     });
     count = agreements.length;
   } else {
-    throw errorWithCode('Unable to determine user roll', 500);
+    throw errorWithCode('Unable to determine user role', 500);
   }
 
   return count;
@@ -374,18 +372,7 @@ router.get(
           ? await agreementCountForUser(req.user)
           : await agreementCountForZones(zones);
 
-      if (user.canReadAll()) {
-        agreements = await getAgreementsForAdmin({
-          undefined,
-          undefined,
-          orderBy,
-          order,
-        });
-        totalItems = agreements.length;
-        const startIndex = (page - 1) * limit;
-        const endIndex = startIndex + limit;
-        agreements = agreements.slice(startIndex, endIndex);
-      } else if (user.isAgreementHolder()) {
+      if (user.isAgreementHolder()) {
         agreements = await getAgreeementsForAH({
           user,
           undefined,
@@ -397,7 +384,9 @@ router.get(
         const startIndex = (page - 1) * limit;
         const endIndex = startIndex + limit;
         agreements = agreements.slice(startIndex, endIndex);
-      } else if (user.isRangeOfficer()) {
+      } else if (user.isAdministrator() || 
+                 user.canReadAll() || 
+                 user.isRangeOfficer()) {
         if (zones.length === 0) {
           agreements = await getAgreementsForRangeOfficer({
             user,
@@ -427,17 +416,6 @@ router.get(
       } else if (user.isDecisionMaker()) {
         agreements = await getAgreeementsForDM({
           user,
-          undefined,
-          undefined,
-          orderBy,
-          order,
-        });
-        totalItems = agreements.length;
-        const startIndex = (page - 1) * limit;
-        const endIndex = startIndex + limit;
-        agreements = agreements.slice(startIndex, endIndex);
-      } else if (user.isAdministrator()) {
-        agreements = await getAgreementsForAdmin({
           undefined,
           undefined,
           orderBy,

--- a/src/router/routes_v1/roles.js
+++ b/src/router/routes_v1/roles.js
@@ -1,0 +1,13 @@
+/* eslint-env es6 */
+
+'use strict';
+
+import { asyncMiddleware } from '@bcgov/nodejs-common-utils';
+import { Router } from 'express';
+import { RoleController } from '../controllers_v1/RoleController';
+
+const router = new Router();
+
+// Get all roles
+router.get('/', asyncMiddleware(RoleController.allRoles));
+module.exports = router;

--- a/src/router/routes_v1/user.js
+++ b/src/router/routes_v1/user.js
@@ -47,4 +47,8 @@ router.delete(
 );
 
 router.post('/:userId?/merge', asyncMiddleware(UserController.mergeAccounts));
+
+// Assign role to user
+router.post('/:userId?/assignRole', asyncMiddleware(UserController.assignUserRole));
+
 module.exports = router;


### PR DESCRIPTION
- Add migration for roles and permissions tables
- [rebase] Integrate getter for permissions in passport
- Edit getter and add setter based on SSO roles for roles and permissions in passport
- Quick change to ensure roleid is added
- Pair with web for commit 1 to allow read only permission
- WIP update role migration, modules might be broken
- Add backend functionality for assigning roles page to pair with commit 2
- Include final migration change for future roles/permissions changes
